### PR TITLE
Remove GenLayer CLI Contributing section

### DIFF
--- a/pages/developers/intelligent-contracts/tools/genlayer-cli.mdx
+++ b/pages/developers/intelligent-contracts/tools/genlayer-cli.mdx
@@ -76,34 +76,6 @@ To initialize the GenLayer Studio with specific parameters:
 genlayer init --numValidators 10 --branch develop
 ```
 
-## Contributing
-Contributions to the GenLayer CLI are welcome! Feel free to fork the repository, make your changes, and submit a pull request. Your efforts to improve the software are greatly appreciated.
-To run the CLI from the repository:
-1. Clone the repository:
-
-```bash
-  git clone https://github.com/yeagerai/genlayer-cli.git
-```
-
-2. Navigate to the project directory and install dependencies:
-
-```bash
-  cd genlayer-cli
-  npm install
-```
-
-3. Start the build process:
-
-```bash
-  npm run dev
-```
-This will continuously rebuild the CLI from the source.
-In another terminal window, execute CLI commands like:
-
-```bash
-  node dist/index.js init
-```
-
 ## Testing
 The GenLayer CLI uses Jest with ts-jest for testing TypeScript files.
 To run tests:


### PR DESCRIPTION
Fixes: DXP-2

## Summary
- remove the Contributing section from the GenLayer CLI docs

## Testing
- `npm run build` *(fails: next not found)*