### PR TITLE
add comput3 provider

### DIFF
--- a/pages/validators/setup-guide.mdx
+++ b/pages/validators/setup-guide.mdx
@@ -210,7 +210,7 @@ You need to set up an LLM for your node to use to provide answers to natural lan
 
   **[Heurist](https://www.heurist.ai/)** - A Layer 2 network for AI model hosting and inference, built on the ZK Stack. It offers serverless access to open-source AI models through a decentralized network. GenLayer Validators can obtain free [Heurist API credits](https://dev-api-form.heurist.ai) by using the referral code: _"genlayer"_.
 
-  **[Comput3](https://genlayer.comput3.ai/)** - A decentralized compute network providing access to various AI models. GenLayer Validators can obtain free [Comput3 API credits](https://genlayer.comput3.ai/) to get started with their validator setup.
+  **[Comput3](https://genlayer.comput3.ai/)** - A decentralized compute network providing access to various AI models. GenLayer Validators can use the Comput3.ai inferencing API with access to llama3, hermes3 and qwen3 models. Validators can obtain free [Comput3 API credits](https://genlayer.comput3.ai/) to get started with their validator setup.
 </Callout>
 
 The GenVM configuration files are located at `third_party/genvm/config/`


### PR DESCRIPTION
depends on new release after https://github.com/genlayerlabs/genlayer-node/pull/394
fixes https://linear.app/genlayer-labs/issue/NOD-261/add-compute3-to-preconfigured-llm-configurations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the validator setup guide to include instructions for multiple LLM providers.
  - Added information and links for obtaining free credits from both Heurist and Comput3.
  - Expanded environment variable setup instructions to cover multiple LLM API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->