### PR TITLE
add comput3 partners onepager

### DIFF
--- a/pages/validators/setup-guide.mdx
+++ b/pages/validators/setup-guide.mdx
@@ -16,7 +16,7 @@ Possible options:
 
 - Run an open-source model locally on the same machine with a GPU
 - Run an open-source model on a different machine
-- Connect to a hosted inference provider (OpenAI, Anthropic, Heurist, Atoma network etc.)
+- Connect to a hosted inference provider (OpenAI, Anthropic, Heurist, Comput3, Atoma network etc.)
 
 ### ZKSync Full Node for the GenLayer Chain
 
@@ -208,9 +208,9 @@ You need to set up an LLM for your node to use to provide answers to natural lan
 <Callout>
   GenLayer has partnered with multiple LLM providers to offer free credits for validators:
 
-  **[Heurist](https://www.heurist.ai/)** - A Layer 2 network for AI model hosting and inference, built on the ZK Stack. It offers serverless access to open-source AI models through a decentralized network. GenLayer Validators can obtain free [Heurist API credits](https://dev-api-form.heurist.ai) by using the referral code: _"genlayer"_.
+  **[Heurist](../partners/heurist)** - A Layer 2 network for AI model hosting and inference, built on the ZK Stack. It offers serverless access to open-source AI models through a decentralized network. GenLayer Validators can obtain free [Heurist API credits](https://dev-api-form.heurist.ai) by using the referral code: _"genlayer"_.
 
-  **[Comput3](https://genlayer.comput3.ai/)** - A decentralized compute network providing access to various AI models. GenLayer Validators can use the Comput3.ai inferencing API with access to llama3, hermes3 and qwen3 models. Validators can obtain free [Comput3 API credits](https://genlayer.comput3.ai/) to get started with their validator setup.
+  **[Comput3](../partners/comput3)** - A decentralized compute network providing access to various AI models. GenLayer Validators can use the Comput3.ai inferencing API with access to llama3, hermes3 and qwen3 models. Validators can obtain free [Comput3 API credits](https://genlayer.comput3.ai/) to get started with their validator setup.
 </Callout>
 
 The GenVM configuration files are located at `third_party/genvm/config/`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new page introducing Comput3.ai as a partner, detailing their scalable GPU compute services and integration with GenLayer Validators.
  * Updated the Validators setup guide to include Comput3 as a hosted inference provider.
  * Changed partner links for Heurist and Comput3 to internal references for easier navigation.
  * Provided instructions for Validators to access and use Comput3’s API, including model options, free credits, and support resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->