### PR TITLE
add ionet as provider

### DIFF
--- a/pages/partners/_meta.json
+++ b/pages/partners/_meta.json
@@ -1,4 +1,5 @@
 {
     "yeager": "Yeager AI",
-    "heurist": "Heurist"
+    "heurist": "Heurist",
+    "ionet": "io.net"
 }

--- a/pages/partners/ionet.mdx
+++ b/pages/partners/ionet.mdx
@@ -1,0 +1,7 @@
+# io.net
+
+io.intelligence is an AI infrastructure and API platform that democratizes access to advanced AI models and AI agents for the IO community and AI developers. It allows users to access and integrate pre-trained open-source models and custom AI agents into their applications via API calls. io.intelligence is powered by [io.net](https://io.net)'s decentralized distributed compute network.
+
+In partnership with GenLayer, [io.net](https://io.net) provides access to over 25 of the top open source models including latest versions of Deepseek, Qwen, Llama and Mistral through one unified API endpoint. Developers on Genlayer can receive free daily compute tokens to access io.intelligence for Enterprise. Complete a short [form](https://form.typeform.com/to/pDmCCViV) to get started.
+
+API Reference: https://docs.io.net/reference/get-started-with-io-intelligence-api 

--- a/pages/validators/setup-guide.mdx
+++ b/pages/validators/setup-guide.mdx
@@ -212,7 +212,7 @@ You need to set up an LLM for your node to use to provide answers to natural lan
 
   **[Comput3](https://genlayer.comput3.ai/)** - A decentralized compute network providing access to various AI models. GenLayer Validators can use the Comput3.ai inferencing API with access to llama3, hermes3 and qwen3 models. Validators can obtain free [Comput3 API credits](https://genlayer.comput3.ai/) to get started with their validator setup.
 
-  **[io.net](https://io.net)** - A decentralized compute network providing GPU access for AI inference. GenLayer Validators can create an account at [id.io.net](https://id.io.net/login) and obtain free credits by [filling out this form](https://form.typeform.com/to/pDmCCViV).
+  **[io.net](/partners/ionet)** - A decentralized compute network providing GPU access for AI inference. GenLayer Validators can create an account at [id.io.net](https://id.io.net/login) and obtain free credits by [filling out this form](https://form.typeform.com/to/pDmCCViV).
 </Callout>
 
 The GenVM configuration files are located at `third_party/genvm/config/`

--- a/pages/validators/setup-guide.mdx
+++ b/pages/validators/setup-guide.mdx
@@ -211,6 +211,8 @@ You need to set up an LLM for your node to use to provide answers to natural lan
   **[Heurist](https://www.heurist.ai/)** - A Layer 2 network for AI model hosting and inference, built on the ZK Stack. It offers serverless access to open-source AI models through a decentralized network. GenLayer Validators can obtain free [Heurist API credits](https://dev-api-form.heurist.ai) by using the referral code: _"genlayer"_.
 
   **[Comput3](https://genlayer.comput3.ai/)** - A decentralized compute network providing access to various AI models. GenLayer Validators can use the Comput3.ai inferencing API with access to llama3, hermes3 and qwen3 models. Validators can obtain free [Comput3 API credits](https://genlayer.comput3.ai/) to get started with their validator setup.
+
+  **[io.net](https://io.net)** - A decentralized compute network providing GPU access for AI inference. GenLayer Validators can create an account at [id.io.net](https://id.io.net/login) and obtain free credits by [filling out this form](https://form.typeform.com/to/pDmCCViV).
 </Callout>
 
 The GenVM configuration files are located at `third_party/genvm/config/`
@@ -223,7 +225,7 @@ You can turn on and off various LLMs by setting the `enabled` field to `false`.
 
 At this stage, select one LLM and set all other to disabled.
 
-Note environment variable names for LLM API keys (e.g., `HEURISTKEY`, `COMPUT3KEY`). You will need to ensure the appropriate key is correctly set before [running the node](#running-the-node).
+Note environment variable names for LLM API keys (e.g., `HEURISTKEY`, `COMPUT3KEY`, `IOINTELLIGENCE_API_KEY`). You will need to ensure the appropriate key is correctly set before [running the node](#running-the-node).
 
 #### `genvm-module-web.yaml`
 
@@ -360,6 +362,9 @@ To ensure your node is correctly configured, you can run the following command:
     
     # For Comput3
     export COMPUT3KEY='your_comput3_api_key'
+    
+    # For io.net
+    export IOINTELLIGENCE_API_KEY='your_ionet_api_key'
     
     # For other providers, use the appropriate environment variable name
     ```


### PR DESCRIPTION
superseeds https://github.com/genlayerlabs/genlayer-docs/pull/229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added io.net (io.intelligence) as a new AI infrastructure and API platform partner, including a dedicated partner page.
  * Updated validator setup documentation to include instructions for using io.net as an LLM provider, with details on obtaining API keys and free credits.
* **Documentation**
  * Expanded partner and validator documentation to reflect the addition of io.net and its integration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->