### PR TITLE
rename yeagerai to genlayerlabs

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 YeagerAI
+Copyright (c) 2024 GenLayer Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ The live site is available at [https://docs.genlayer.com/](https://docs.genlayer
 
 ## License
 
-Text and diagrams: [Creative Commons Attribution 4.0 International](https://github.com/yeagerai/genlayer-docs/blob/main/LICENSES/CC-BY-4.0.txt).
+Text and diagrams: [Creative Commons Attribution 4.0 International](https://github.com/genlayerlabs/genlayer-docs/blob/main/LICENSES/CC-BY-4.0.txt).
 
-Code snippets and examples: [MIT License](https://github.com/yeagerai/genlayer-docs/blob/main/LICENSES/MIT.txt).
+Code snippets and examples: [MIT License](https://github.com/genlayerlabs/genlayer-docs/blob/main/LICENSES/MIT.txt).

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/yeagerai/genlayer-docs.git"
+    "url": "git+https://github.com/genlayerlabs/genlayer-docs.git"
   },
   "author": "GenLayer",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/yeagerai/genlayer-docs/issues"
+    "url": "https://github.com/genlayerlabs/genlayer-docs/issues"
   },
-  "homepage": "https://github.com/yeagerai/genlayer-docs#readme",
+  "homepage": "https://github.com/genlayerlabs/genlayer-docs#readme",
   "dependencies": {
     "clsx": "^2.1.1",
     "next": "^15.0.0",

--- a/pages/api-references/genlayer-test.mdx
+++ b/pages/api-references/genlayer-test.mdx
@@ -2,7 +2,7 @@
 
 This document describes the key components and methods available in the GenLayer Test SDK for testing Intelligent Contracts.
 
-For comprehensive test examples and implementation patterns, see our [Test Suite Examples](https://github.com/yeagerai/genlayer-testing-suite/tree/main/tests/examples).
+For comprehensive test examples and implementation patterns, see our [Test Suite Examples](https://github.com/genlayerlabs/genlayer-testing-suite/tree/main/tests/examples).
 
 ## Installation
 

--- a/pages/developers/decentralized-applications/genlayer-js.mdx
+++ b/pages/developers/decentralized-applications/genlayer-js.mdx
@@ -74,7 +74,7 @@ Additional features are planned to enhance interaction with the GenLayer network
 
 You can find the GenLayerJS SDK repository on GitHub:
 
-[GenLayerJS SDK Repository](https://github.com/yeagerai/genlayer-js)
+[GenLayerJS SDK Repository](https://github.com/genlayerlabs/genlayer-js)
 
 ## Full Reference
 

--- a/pages/developers/decentralized-applications/project-boilerplate.mdx
+++ b/pages/developers/decentralized-applications/project-boilerplate.mdx
@@ -5,7 +5,7 @@ import { Callout } from 'nextra-theme-docs'
 The GenLayer Project Boilerplate is a template for building decentralized applications (DApps) on GenLayer. This boilerplate includes a complete example implementation of a football prediction market, demonstrating best practices and common patterns for GenLayer development.
 
 <Callout type="info">
-    This boilerplate is a work in progress and is not yet ready for production use. You can find the latest version at: [GenLayer Project Boilerplate](https://github.com/yeagerai/genlayer-project-boilerplate)
+    This boilerplate is a work in progress and is not yet ready for production use. You can find the latest version at: [GenLayer Project Boilerplate](https://github.com/genlayerlabs/genlayer-project-boilerplate)
 </Callout>
 
 
@@ -54,7 +54,7 @@ Before using the GenLayer Project Boilerplate, ensure your system meets the foll
 
 1. Clone the boilerplate repository:
 ```bash
-git clone https://github.com/yeagerai/genlayer-project-boilerplate
+git clone https://github.com/genlayerlabs/genlayer-project-boilerplate
 cd genlayer-project-boilerplate
 ```
 

--- a/pages/developers/intelligent-contracts/examples/prediction.mdx
+++ b/pages/developers/intelligent-contracts/examples/prediction.mdx
@@ -87,7 +87,7 @@ class PredictionMarket(gl.Contract):
         return result_json
 ```
 
-You can check out this code on our [GitHub](https://github.com/yeagerai/genlayer-simulator/blob/main/examples/contracts/football_prediction_market.py)
+You can check out this code on our [GitHub](https://github.com/genlayerlabs/genlayer-simulator/blob/main/examples/contracts/football_prediction_market.py)
 
 ## Deploying the Contract
 

--- a/pages/developers/intelligent-contracts/examples/wizard-of-coin.mdx
+++ b/pages/developers/intelligent-contracts/examples/wizard-of-coin.mdx
@@ -58,7 +58,7 @@ This result should be perfectly parseable by a JSON parser without errors.
         return self.have_coin
 ```
 
-You can check out this code on our [GitHub](https://github.com/yeagerai/genlayer-simulator/blob/main/examples/contracts/wizard_of_coin.py)
+You can check out this code on our [GitHub](https://github.com/genlayerlabs/genlayer-simulator/blob/main/examples/contracts/wizard_of_coin.py)
 
 ## Deploying the Contract
 

--- a/pages/developers/intelligent-contracts/tooling-setup.mdx
+++ b/pages/developers/intelligent-contracts/tooling-setup.mdx
@@ -133,7 +133,7 @@ Refer to the [Your First Contract](./your-first-contract) page for more informat
 
 ## Writing End-to-End Tests with genlayer-project-boilerplate
 
-The [genlayer-project-boilerplate](https://github.com/yeagerai/genlayer-project-boilerplate/) provides a starting point for writing end-to-end (e2e) tests for your Intelligent Contracts.
+The [genlayer-project-boilerplate](https://github.com/genlayerlabs/genlayer-project-boilerplate/) provides a starting point for writing end-to-end (e2e) tests for your Intelligent Contracts.
 
 ### Setting Up the Boilerplate
 
@@ -141,7 +141,7 @@ The [genlayer-project-boilerplate](https://github.com/yeagerai/genlayer-project-
 
 On a location different from the GenLayer Studio, clone the repository:
 ```bash
-  git clone https://github.com/yeagerai/genlayer-project-boilerplate.git
+  git clone https://github.com/genlayerlabs/genlayer-project-boilerplate.git
 ```
 
 2. **Install Dependencies**
@@ -205,7 +205,7 @@ On a location different from the GenLayer Studio, clone the repository:
 
 You can build a frontend decentralized application (dApp) that interacts with your Intelligent Contract using GenLayerJS, a JavaScript SDK for GenLayer.
 
-You can start by cloning the [genlayer-dapp-boilerplate](https://github.com/yeagerai/genlayer-project-boilerplate/) repository or start from scratch with a new frontend project.
+You can start by cloning the [genlayer-dapp-boilerplate](https://github.com/genlayerlabs/genlayer-project-boilerplate/) repository or start from scratch with a new frontend project.
 
 After you have your project ready, continue with the following steps:
 

--- a/pages/developers/intelligent-contracts/tools/genlayer-cli.mdx
+++ b/pages/developers/intelligent-contracts/tools/genlayer-cli.mdx
@@ -89,7 +89,7 @@ Additional commands are planned to enhance interaction with the GenLayer Studio.
 
 ## Repository
 You can find the GenLayer CLI repository on GitHub:
-[GenLayer CLI Repository](https://github.com/yeagerai/genlayer-cli)
+[GenLayer CLI Repository](https://github.com/genlayerlabs/genlayer-cli)
 
 ## Full Reference
 

--- a/pages/developers/intelligent-contracts/tools/genlayer-studio/advanced-features/custom-plugins.mdx
+++ b/pages/developers/intelligent-contracts/tools/genlayer-studio/advanced-features/custom-plugins.mdx
@@ -23,7 +23,7 @@ In addition to these built-in providers, you have the flexibility to integrate y
 
 ### Creating the Plugin
 
-To integrate a new LLM provider plugin, you need to implement the `Plugin` protocol defined in the [llms.py](https://github.com/yeagerai/genlayer-simulator/blob/main/backend/node/genvm/llms.py) file. The protocol is structured as follows:
+To integrate a new LLM provider plugin, you need to implement the `Plugin` protocol defined in the [llms.py](https://github.com/genlayerlabs/genlayer-simulator/blob/main/backend/node/genvm/llms.py) file. The protocol is structured as follows:
 
 ```python
 class Plugin(Protocol):
@@ -107,7 +107,7 @@ plugin_map = {
 
 ## Updating the JSON Schema
 
-To maintain consistency and enable proper configuration validation, you must update the [JSON schema](https://json-schema.org/) in the [`providers_schema.json`](https://github.com/yeagerai/genlayer-simulator/blob/main/backend/node/create_nodes/providers_schema.json) file. This update should include your new provider and its specific configuration options.
+To maintain consistency and enable proper configuration validation, you must update the [JSON schema](https://json-schema.org/) in the [`providers_schema.json`](https://github.com/genlayerlabs/genlayer-simulator/blob/main/backend/node/create_nodes/providers_schema.json) file. This update should include your new provider and its specific configuration options.
 
 The JSON schema plays a crucial role in validating the configuration options for each provider, ensuring that users input correct and compatible settings.
 

--- a/pages/partners/_meta.json
+++ b/pages/partners/_meta.json
@@ -1,5 +1,5 @@
 {
-    "yeager": "Yeager AI",
+    "genlayerlabs": "GenLayer Labs",
     "heurist": "Heurist",
     "ionet": "io.net"
 }

--- a/pages/partners/genlayerlabs.mdx
+++ b/pages/partners/genlayerlabs.mdx
@@ -1,0 +1,6 @@
+## GenLayer Labs
+
+[GenLayer Labs](https://www.genlayerlabs.com/) is a pioneering AI research lab dedicated to revolutionizing human-AI interaction. They are one of the core developers of GenLayer, focusing on using AI to enhance the performance, security, and scalability of blockchain networks. By embedding AI into the blockchain's core, GenLayer Labs enables decentralized applications to make smart decisions autonomously, opening new possibilities for automation and efficiency in various industries.
+
+We encourage other developers and organizations to collaborate with GenLayer Labs on this groundbreaking project. Together, we can push the boundaries of what AI and blockchain technology can achieve. 
+

--- a/pages/partners/yeager.mdx
+++ b/pages/partners/yeager.mdx
@@ -1,6 +1,0 @@
-## Yeager AI
-
-[YeagerAI](https://www.yeager.ai/) is a pioneering AI research lab dedicated to revolutionizing human-AI interaction. They are one of the core developers of GenLayer, focusing on using AI to enhance the performance, security, and scalability of blockchain networks. By embedding AI into the blockchain’s core, YeagerAI enables decentralized applications to make smart decisions autonomously, opening new possibilities for automation and efficiency in various industries.
-
-We encourage other developers and organizations to collaborate with YeagerAI on this groundbreaking project. Together, we can push the boundaries of what AI and blockchain technology can achieve. 
-

--- a/pages/understand-genlayer-protocol/core-concepts/genvm.mdx
+++ b/pages/understand-genlayer-protocol/core-concepts/genvm.mdx
@@ -2,7 +2,7 @@
 
 The GenVM is the execution environment for Intelligent Contracts in the GenLayer protocol. It serves as the backbone for processing and managing contract operations within the GenLayer ecosystem.
 
-[Source code at GitHub](https://github.com/yeagerai/genvm)
+[Source code at GitHub](https://github.com/genlayerlabs/genvm)
 
 ## Purpose of GenVM
 

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -9,9 +9,9 @@ import DiscordIcon from "./components/discord";
 const config: DocsThemeConfig = {
   logo: <Logo />,
   project: {
-    link: "https://github.com/yeagerai/genlayer-simulator",
+    link: "https://github.com/genlayerlabs/genlayer-simulator",
   },
-  docsRepositoryBase: "https://github.com/yeagerai/genlayer-docs",
+  docsRepositoryBase: "https://github.com/genlayerlabs/genlayer-docs",
   footer: {
     text: "GenLayer Documentation",
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all references and URLs from "YeagerAI" or "yeagerai" to "GenLayer Labs" or "genlayerlabs" across documentation, metadata, and configuration.
  * Replaced the partner entry and page for Yeager AI with GenLayer Labs, including a new introduction page for GenLayer Labs.
  * Corrected repository, license, and example links to reflect the new GitHub organization.
  * Removed outdated Yeager AI partner content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->