### PR TITLE
docs; fix link to github page

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -9,7 +9,7 @@ import DiscordIcon from "./components/discord";
 const config: DocsThemeConfig = {
   logo: <Logo />,
   project: {
-    link: "https://github.com/genlayerlabs/genlayer-simulator",
+    link: "https://github.com/genlayerlabs/",
   },
   docsRepositoryBase: "https://github.com/genlayerlabs/genlayer-docs/tree/main",
   footer: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project link in the theme to direct users to the main GitHub organization page instead of a specific repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->