### PR TITLE
chore(sanitize-config): Update sanitization logic to remove only dev sections and add tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!--
+Please update the pull request title using the Conventional Commits format: <type>[optional scope]: <description>
+
+Examples:
+- feat(logging): add support for customizable log levels
+- fix(authentication): resolve token expiration issue
+- docs(readme): update installation instructions
+
+Types:
+- feat: Introduces a new feature
+- fix: Addresses a bug fix
+- docs: Pertains to documentation changes
+- style: Relates to code style changes (e.g., formatting)
+- refactor: Refactors code without adding features or fixing bugs
+- test: Adds or modifies tests
+- chore: Miscellaneous tasks (e.g., updating build processes)
+
+For comprehensive guidelines, please refer to the Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/
+-->
+
+## Description
+
+<!-- Provide a detailed description of your changes. -->
+
+<!-- If it fixes an open issue, please close the related issue here (e.g., Closes #123). -->
+<!-- Delete this explanation and the line below if not applicable. -->

--- a/.github/scripts/sanitize-config.py
+++ b/.github/scripts/sanitize-config.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-Sanitize GenLayer node configuration by removing dev and admin sections.
+Sanitize GenLayer node configuration by removing dev sections.
 
 This script is used by the GitHub Actions workflow to prepare the config
-for documentation by removing sensitive sections.
+for documentation by removing development-only sections.
 """
 
 import sys
@@ -34,7 +34,7 @@ def find_section_end(lines, start_idx, base_indent):
 
 
 def sanitize_config(config_file_path):
-    """Remove node.dev and node.admin sections from config file."""
+    """Remove node.dev sections from config file."""
     print(f"Sanitizing config file: {config_file_path}")
     
     # Read the YAML file
@@ -49,14 +49,14 @@ def sanitize_config(config_file_path):
     # Track lines to remove
     lines_to_remove = set()
     
-    # Find and mark node.admin and node.dev sections
+    # Find and mark node.dev sections
     i = 0
     while i < len(lines):
         line = lines[i]
         stripped = line.strip()
         
-        # Check if this is an admin: or dev: line under node:
-        if stripped in ['admin:', 'dev:']:
+        # Check if this is a dev: line under node:
+        if stripped == 'dev:':
             # Get the indentation of this line
             indent = len(line) - len(line.lstrip())
             

--- a/.github/scripts/test_sanitize_config.py
+++ b/.github/scripts/test_sanitize_config.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Test script for sanitize-config.py"""
+
+import os
+import sys
+import tempfile
+
+# Import sanitize_config function directly
+import importlib.util
+spec = importlib.util.spec_from_file_location("sanitize_config", 
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "sanitize-config.py"))
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+sanitize_config = module.sanitize_config
+
+def test_sanitize_config():
+    """Test that the sanitize_config function removes only dev sections."""
+    
+    # Test config with admin and dev sections
+    test_config = """# node configuration
+node:
+  # Mode can be "validator" or "archive".
+  mode: "validator"
+  admin:
+    port: 9155
+  rpc:
+    port: 9151
+    endpoints:
+      groups:
+        genlayer: true
+      methods:
+        gen_call: true
+  ops:
+    port: 9153
+    endpoints:
+      metrics: true
+      health: true
+  dev:
+    disableSubscription: false
+
+# genvm configuration
+genvm:
+  bin_dir: ./third_party/genvm/bin
+  manage_modules: true
+"""
+    
+    # Create a temporary file
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        f.write(test_config)
+        temp_file = f.name
+    
+    try:
+        # Run sanitize_config
+        print("Testing sanitize_config...")
+        sanitize_config(temp_file)
+        
+        # Read the result
+        with open(temp_file, 'r') as f:
+            result_content = f.read()
+        
+        # Verify the results by checking the content
+        print("\nVerifying results...")
+        
+        # Check that node section exists
+        assert 'node:' in result_content, "node section should exist"
+        
+        # Check that admin is preserved and dev is removed
+        assert 'admin:' in result_content, "admin section should be preserved"
+        assert 'port: 9155' in result_content, "admin port should be preserved"
+        assert 'dev:' not in result_content, "dev section should be removed"
+        assert 'disableSubscription:' not in result_content, "dev content should be removed"
+        
+        # Check that other sections are preserved
+        assert 'rpc:' in result_content, "rpc section should be preserved"
+        assert 'ops:' in result_content, "ops section should be preserved"
+        assert 'port: 9151' in result_content, "rpc port should be preserved"
+        assert 'port: 9153' in result_content, "ops port should be preserved"
+        assert 'endpoints:' in result_content, "endpoints should be preserved"
+        assert 'groups:' in result_content, "groups should be preserved"
+        assert 'methods:' in result_content, "methods should be preserved"
+        
+        # Check that genvm section is preserved
+        assert 'genvm:' in result_content, "genvm section should exist"
+        assert 'manage_modules: true' in result_content, "genvm settings should be preserved"
+        
+        print("✅ All tests passed!")
+        
+        # Print the sanitized config
+        print("\nSanitized config:")
+        print(result_content)
+        
+    finally:
+        # Clean up
+        os.unlink(temp_file)
+
+if __name__ == "__main__":
+    test_sanitize_config()

--- a/.github/workflows/sync-docs-from-node.yml
+++ b/.github/workflows/sync-docs-from-node.yml
@@ -306,7 +306,7 @@ jobs:
             grep -E "zksync.*url:" "$TEMP_CONFIG" || echo "No zksync URLs found after sed"
             echo "::endgroup::"
             
-            # Remove node.dev and node.admin sections using Python for reliable YAML parsing
+            # Remove node.dev sections using Python for reliable YAML parsing
             echo "::group::Debug: Running Python sanitization"
             echo "Script path: .github/scripts/sanitize-config.py"
             echo "Config path: $TEMP_CONFIG"
@@ -343,7 +343,7 @@ jobs:
               echo "================================="
               echo ""
               echo "Checking for removed sections:"
-              grep -E "^\s*(dev|admin):" "$TEMP_CONFIG" && echo "WARNING: dev/admin sections still present!" || echo "Good: No dev/admin sections found"
+              grep -E "^\s*dev:" "$TEMP_CONFIG" && echo "WARNING: dev sections still present!" || echo "Good: No dev sections found"
               
               # Verify the sanitized file has the expected structure
               echo "Verifying config structure:"
@@ -429,7 +429,7 @@ jobs:
               echo "Has node section: $(grep -q '^node:' "$DEST_CONFIG" && echo "Yes" || echo "No")"
               echo "Has consensus section: $(grep -q '^consensus:' "$DEST_CONFIG" && echo "Yes" || echo "No")"
               echo "Has dev section: $(grep -q '^\s*dev:' "$DEST_CONFIG" && echo "Yes - ERROR!" || echo "No - Good")"
-              echo "Has admin section: $(grep -q '^\s*admin:' "$DEST_CONFIG" && echo "Yes - ERROR!" || echo "No - Good")"
+              echo "Has admin section: $(grep -q '^\s*admin:' "$DEST_CONFIG" && echo "Yes" || echo "No")"
             else
               echo "ERROR: Destination config still doesn't exist!"
             fi
@@ -725,7 +725,7 @@ jobs:
             head -30 "$CONFIG_PATH"
             echo "---"
             echo "Checking for sensitive sections:"
-            grep -E "^\s*(dev|admin):" "$CONFIG_PATH" && echo "ERROR: Sensitive sections found!" || echo "✓ No sensitive sections"
+            grep -E "^\s*dev:" "$CONFIG_PATH" && echo "ERROR: Dev section found!" || echo "✓ No dev section"
             echo "Checking for TODO placeholders:"
             grep -i "TODO:" "$CONFIG_PATH" && echo "✓ TODO placeholders found" || echo "WARNING: No TODO placeholders"
           else


### PR DESCRIPTION
## Description

This PR updates the configuration sanitization logic in the documentation sync workflow to preserve the `admin` section while only removing the `dev` section from the GenLayer node configuration files. Previously, both `admin` and `dev` sections were being removed during the documentation sync process. 

The change includes:
- Modified `sanitize-config.py` to only target and remove `dev:` sections
- Added comprehensive test suite `test_sanitize_config.py` to verify the sanitization behavior
- Updated workflow comments and debug messages to reflect the new behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a pull request template to guide contributors on formatting titles and descriptions according to Conventional Commits.
  * Added a standalone test script to verify configuration file sanitization.

* **Documentation**
  * Updated script documentation and comments to reflect changes in configuration sanitization.

* **Chores**
  * Modified workflow to only remove and check for the `dev` section in configuration files, leaving the `admin` section unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->