### PR TITLE
docs(cli): switch to genlayer localnet validators

### DIFF
--- a/pages/api-references/genlayer-cli.mdx
+++ b/pages/api-references/genlayer-cli.mdx
@@ -236,13 +236,13 @@ EXAMPLES:
    genlayer update ollama --model deepseek-r1 --remove
 ```
 
-### Validator Management
+### Localnet Validator Management
 
-Manage validator operations.
+Manage localnet validator operations.
 
 ```bash
 USAGE:
-   genlayer validators <command> [options]
+   genlayer localnet validators <command> [options]
 
 COMMANDS:
    get [--address <validatorAddress>]     Retrieve details of a specific validator or all validators
@@ -264,21 +264,21 @@ OPTIONS (create-random):
    --models <models...>                   Space-separated list of model names (e.g., gpt-4 gpt-4o)
 
 OPTIONS (create):
-   --stake <stake>                        Stake amount for the validator (default: 1)
+   --stake <stake>                        Stake amount for the validator (default: "1")
    --config <config>                      Optional JSON configuration for the validator
    --provider <provider>                  Specify the provider for the validator
    --model <model>                        Specify the model for the validator
 
 EXAMPLES:
-   genlayer validators get
-   genlayer validators get --address 0x123456789abcdef
+   genlayer localnet validators get
+   genlayer localnet validators get --address 0x123456789abcdef
 
-   genlayer validators count
-   genlayer validators delete --address 0x123456789abcdef
-   genlayer validators update 0x123456789abcdef --stake 100 --provider openai --model gpt-4
+   genlayer localnet validators count
+   genlayer localnet validators delete --address 0x123456789abcdef
+   genlayer localnet validators update 0x123456789abcdef --stake 100 --provider openai --model gpt-4
 
-   genlayer validators create
-   genlayer validators create --stake 50 --provider openai --model gpt-4
-   genlayer validators create-random --count 3 --providers openai --models gpt-4 gpt-4o
+   genlayer localnet validators create
+   genlayer localnet validators create --stake 50 --provider openai --model gpt-4
+   genlayer localnet validators create-random --count 3 --providers openai --models gpt-4 gpt-4o
 
 ```


### PR DESCRIPTION
### Description

- Update CLI docs to use `genlayer localnet validators` instead of `genlayer validators`.
- Refresh USAGE, COMMANDS, OPTIONS, and EXAMPLES to match current CLI behavior.
- File: `pages/api-references/genlayer-cli.mdx`. Docs-only change; no functional impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI docs to scope validator management under localnet.
  * Revised usage to “genlayer localnet validators …” for all validator commands.
  * Clarified default stake value formatting in options.
  * Refreshed all examples (get, get --address, count, create, create-random, update, delete) to match the localnet namespace.
  * Improved headings and descriptions to consistently reference localnet validator management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->