### PR TITLE
CON-349: Update Spec and Website related to the validator Exit flow

### DIFF
--- a/pages/understand-genlayer-protocol/core-concepts/optimistic-democracy/staking.mdx
+++ b/pages/understand-genlayer-protocol/core-concepts/optimistic-democracy/staking.mdx
@@ -214,9 +214,33 @@ Rewards automatically increase the stake-per-share ratio without requiring user 
 Both validators and delegators face a **7-epoch unbonding period** when withdrawing:
 
 - Prevents rapid stake movements that could destabilize the network
-- Tokens stop earning rewards immediately upon exit
+- Exit is not processed immediately - validator remains active until next `validatorPrime()` call at next epoch
+- Exited tokens stop earning rewards only after the exit is processed in the next epoch
 - Countdown starts from the exit epoch
 - Funds become claimable when: `current_epoch >= exit_epoch + 7`
+
+**Detailed Exit Flow**:
+
+```
+Epoch N:   validatorExit(all_shares) called
+           → Exit scheduled in contract state
+           → Validator STILL ACTIVE and earning rewards
+           → Can still be selected for consensus participation
+
+Epoch N+1: validatorPrime() called (by anyone)
+           → Exit processed: stake reduced to 0
+           → Removed from validator tree
+           → No longer active or earning rewards
+           → Cannot be selected for new transactions
+
+Epoch N+2: epochAdvance() called
+           → Validator officially not in active validator set
+           → Fully excluded from consensus operations
+
+Epoch N+7: validatorClaim() callable
+           → 7 epochs have passed since exit call (epoch N)
+           → Tokens released to validator owner
+```
 
 ## Validator Priming
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated staking documentation to clarify the validator exit process with a detailed timeline showing the two-step exit mechanism where exit is scheduled but rewards stop only after processing in the next epoch, with visibility into the interim period when validators remain active before being officially removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->