### PR TITLE
ci: add GitHub Actions workflow to clear Netlify cache on merge to main

### DIFF
--- a/.github/workflows/netlify-clear-cache.yml
+++ b/.github/workflows/netlify-clear-cache.yml
@@ -1,0 +1,13 @@
+name: Netlify (clear cache)
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  clear-cache-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Netlify build (clear cache)
+        run: |
+          curl -X POST -d '{}' "${{ secrets.NETLIFY_BUILD_HOOK_URL }}?clear_cache=true&trigger_branch=main&trigger_title=main+clear+cache"


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically triggers a Netlify build with cache clearing whenever code is pushed to the main branch.

This ensures that documentation updates are reflected immediately without stale cached content, improving the reliability of deployments after merges.

Changes:
  - New workflow file .github/workflows/netlify-clear-cache.yml
  - Uses NETLIFY_BUILD_HOOK_URL secret with clear_cache=true parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to automatically clear cache on main branch pushes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->