### PR TITLE
docs(developers): add quick start guide

### DIFF
--- a/pages/developers/intelligent-contracts/_meta.json
+++ b/pages/developers/intelligent-contracts/_meta.json
@@ -1,4 +1,5 @@
 {
+  "quick-start": "Quick Start",
   "introduction": "Introduction to Intelligent Contracts",
   "features": "Feature List",
   "tooling-setup": "Development Setup",

--- a/pages/developers/intelligent-contracts/quick-start.mdx
+++ b/pages/developers/intelligent-contracts/quick-start.mdx
@@ -1,0 +1,253 @@
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Quick Start
+
+Deploy your first Intelligent Contract in about 10 minutes.
+
+---
+
+## Before you start: pick your path
+
+<Tabs items={['No Docker (fastest)', 'With Docker (full)']}>
+  <Tabs.Tab>
+    **GLSim** — a lightweight simulator that implements the GenLayer JSON-RPC protocol.
+    Starts in ~1 second, no Docker required. Ideal for getting started quickly.
+
+    You'll need: **Python 3.12+** and **Node.js 18+**
+  </Tabs.Tab>
+  <Tabs.Tab>
+    **GenLayer Studio (local)** — full GenVM execution with real validator consensus,
+    transaction inspection, and a visual UI. Use this before deploying to testnet.
+
+    You'll need: **Python 3.12+**, **Node.js 18+**, and **Docker 26+**
+  </Tabs.Tab>
+</Tabs>
+
+Both paths use the same contracts, the same CLI, and the same tests. You can switch at any time.
+
+---
+
+<Steps>
+
+### Set up your project
+
+Clone the official boilerplate — it includes a contract template, testing infrastructure, and a frontend scaffold.
+
+```bash
+git clone https://github.com/genlayerlabs/genlayer-project-boilerplate.git my-project
+cd my-project
+pip install -r requirements.txt
+```
+
+This installs two tools:
+- `genlayer-test` — testing framework (direct mode, GLSim, integration tests)
+- `genvm-linter` — static analysis that catches contract errors before you deploy
+
+Your project layout:
+
+```
+contracts/          # Your Intelligent Contracts
+tests/
+  direct/           # Fast in-memory tests — no server needed
+  integration/      # Full end-to-end tests against a GenLayer environment
+frontend/           # Next.js frontend with GenLayerJS pre-wired
+deploy/             # Deployment scripts
+gltest.config.yaml  # Network and account configuration
+```
+
+### Start your environment
+
+<Tabs items={['GLSim (no Docker)', 'GenLayer Studio (Docker)']}>
+  <Tabs.Tab>
+    ```bash
+    pip install genlayer-test[sim]
+    glsim --port 4000 --validators 5
+    ```
+
+    GLSim runs the Python runner natively — not inside GenVM — so there can be minor
+    incompatibilities. Always validate against Studio before deploying to testnet.
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash
+    npm install -g genlayer
+    genlayer init
+    genlayer up
+    ```
+
+    Once running, open [http://localhost:8080](http://localhost:8080) to access the Studio UI.
+    Your tests and frontend connect to the JSON-RPC API at `http://localhost:4000/api`.
+  </Tabs.Tab>
+</Tabs>
+
+### Write your first contract
+
+Create `contracts/hello.py`:
+
+```python
+# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
+
+from genlayer import *
+
+class Hello(gl.Contract):
+    name: str
+
+    def __init__(self, name: str):
+        self.name = name
+
+    @gl.public.view
+    def greet(self) -> str:
+        return f'Hello, {self.name}!'
+
+    @gl.public.write
+    def set_name(self, name: str):
+        self.name = name
+```
+
+A few things every contract needs:
+- **Line 1** — the version comment pins the GenVM version. Required.
+- **`gl.Contract`** — marks this class as an Intelligent Contract.
+- **`@gl.public.view`** — read-only method, no state change.
+- **`@gl.public.write`** — method that modifies on-chain state.
+- **Class-level type annotations** — persistent fields must be declared in the class body. Fields set via `self.field = value` outside the class body are not persisted.
+
+<Callout type="info">
+  The GenLayer Studio auto-detects constructor parameters from your contract code and generates a UI for them — no ABI configuration needed.
+</Callout>
+
+### Lint and test
+
+Catch issues before deploying:
+
+```bash
+# Static analysis — catches forbidden imports, invalid types, missing decorators
+genvm-lint check contracts/hello.py
+
+# Fast in-memory tests — no server, no Docker
+pytest tests/direct/ -v
+```
+
+A minimal direct-mode test looks like this:
+
+```python
+def test_greet(direct_vm, direct_deploy, direct_alice):
+    contract = direct_deploy("contracts/hello.py", args=["World"])
+
+    result = contract.greet()
+    assert result == "Hello, World!"
+
+    direct_vm.sender = direct_alice
+    contract.set_name("GenLayer")
+    assert contract.greet() == "Hello, GenLayer!"
+```
+
+Available fixtures: `direct_vm`, `direct_deploy`, `direct_alice`, `direct_bob`, `direct_charlie`, `direct_owner`.
+
+### Deploy and call
+
+<Tabs items={['Via Studio UI', 'Via CLI']}>
+  <Tabs.Tab>
+    1. Open [http://localhost:8080](http://localhost:8080) (or [studio.genlayer.com](https://studio.genlayer.com) for zero-setup)
+    2. Load `contracts/hello.py`
+    3. Click **Deploy** — Studio detects the `name` parameter and shows an input field
+    4. Call `greet` from the UI to see the output
+
+    You should see `Hello, World!` (or whatever name you passed). That's your first contract running. ✓
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash
+    npm install -g genlayer
+
+    # Deploy — pass constructor args as JSON
+    genlayer deploy contracts/hello.py --args '["World"]'
+    # → Contract deployed at 0xabc...
+
+    # Call a view method (instant, no transaction)
+    genlayer call 0xabc... greet
+    # → "Hello, World!"
+
+    # Call a write method (creates a transaction)
+    genlayer write 0xabc... set_name --args '["GenLayer"]'
+    genlayer call 0xabc... greet
+    # → "Hello, GenLayer!"
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+### Make it intelligent
+
+Now add what no regular smart contract can do — access the web or call an LLM:
+
+```python
+# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
+
+from genlayer import *
+import json
+
+class PriceFeed(gl.Contract):
+    last_price: str
+
+    def __init__(self):
+        self.last_price = "unknown"
+
+    @gl.public.write
+    def update_price(self, ticker: str) -> None:
+        # Non-deterministic operations must run inside a function
+        # passed to gl.eq_principle.* — this is how GenLayer reaches
+        # consensus across validators that may get slightly different results.
+        def fetch() -> str:
+            data = gl.nondet.web.get(
+                f"https://api.coinbase.com/v2/prices/{ticker}-USD/spot"
+            )
+            parsed = json.loads(data)
+            return json.dumps({"price": parsed["data"]["amount"]}, sort_keys=True)
+
+        result = gl.eq_principle.strict_eq(fetch)
+        self.last_price = json.loads(result)["price"]
+
+    @gl.public.view
+    def get_price(self) -> str:
+        return self.last_price
+```
+
+<Callout type="warning">
+  Always use `json.dumps(..., sort_keys=True)` before returning from a `strict_eq` block.
+  Without it, validators may produce differently-ordered JSON and fail to reach consensus.
+</Callout>
+
+The key concept: `gl.eq_principle.strict_eq` tells GenLayer that all validators must
+return byte-identical results. Use this when output is constrained (JSON with fixed keys,
+booleans). For subjective outputs like summaries or classifications, use `prompt_comparative` instead.
+
+→ Deep dive: [Equivalence Principle](/developers/intelligent-contracts/equivalence-principle)
+
+</Steps>
+
+---
+
+## Zero-setup alternative
+
+Don't want to install anything yet? Open [studio.genlayer.com](https://studio.genlayer.com) and
+load any built-in example. You can write, deploy, and call contracts directly in the browser —
+no local setup needed. You can also import any deployed contract by address to interact with it.
+
+---
+
+## What's next?
+
+**Go deeper on Intelligent Contracts**
+- [Equivalence Principle](/developers/intelligent-contracts/equivalence-principle) — how validators reach consensus on non-deterministic outputs
+- [Calling LLMs](/developers/intelligent-contracts/features/calling-llms) — `exec_prompt`, response formats, and choosing the right eq principle
+- [Web Access](/developers/intelligent-contracts/features/web-access) — `web.get` vs `web.render`, modes, and when to use each
+- [Prompt & Data Techniques](/developers/intelligent-contracts/crafting-prompts) — prompt patterns that maximize validator agreement
+- [Best Practices & Common Patterns](/developers/intelligent-contracts/security-and-best-practices/best-practices) — access control, storage patterns, common mistakes, upgrade patterns
+
+**Write proper tests**
+- [Testing](/developers/intelligent-contracts/testing) — direct mode, mocking web/LLM calls, integration tests
+- [Debugging](/developers/intelligent-contracts/debugging) — reading validator execution logs, tracing failed transactions
+
+**Connect a frontend**
+- [DApp Development Workflow](/developers/decentralized-applications/dapp-development-workflow) — full-stack architecture overview
+- [GenLayerJS SDK](/developers/decentralized-applications/genlayer-js) — reading and writing contracts from JavaScript
+
+**Ship to testnet**
+- [Deploying](/developers/intelligent-contracts/deploying) — deployment methods, Testnet Bradbury, network configuration

--- a/pages/developers/intelligent-contracts/quick-start.mdx
+++ b/pages/developers/intelligent-contracts/quick-start.mdx
@@ -185,7 +185,7 @@ Available fixtures: `direct_vm`, `direct_deploy`, `direct_alice`, `direct_bob`, 
 
 ### Make it intelligent
 
-Now add what no regular smart contract can do — call an LLM to decision on-chain:
+Now add what no regular smart contract can do — call an LLM to decide on-chain:
 
 ```python
 # { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }

--- a/pages/developers/intelligent-contracts/quick-start.mdx
+++ b/pages/developers/intelligent-contracts/quick-start.mdx
@@ -185,7 +185,7 @@ Available fixtures: `direct_vm`, `direct_deploy`, `direct_alice`, `direct_bob`, 
 
 ### Make it intelligent
 
-Now add what no regular smart contract can do — call an LLM to make a decision on-chain:
+Now add what no regular smart contract can do — call an LLM to decision on-chain:
 
 ```python
 # { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }

--- a/pages/developers/intelligent-contracts/quick-start.mdx
+++ b/pages/developers/intelligent-contracts/quick-start.mdx
@@ -6,7 +6,17 @@ Deploy your first Intelligent Contract in about 10 minutes.
 
 ---
 
-## Before you start: pick your path
+## Option A: Zero setup — try in the browser
+
+The fastest path to a running contract is [studio.genlayer.com](https://studio.genlayer.com) — open it, pick a built-in example, and click **Deploy**. No installation needed. You can also import any deployed contract by address to interact with it directly.
+
+When you're ready to build locally, continue with Option B below.
+
+---
+
+## Option B: Local development
+
+### Before you start: pick your environment
 
 <Tabs items={['No Docker (fastest)', 'With Docker (full)']}>
   <Tabs.Tab>
@@ -41,7 +51,7 @@ pip install -r requirements.txt
 
 This installs two tools:
 - `genlayer-test` — testing framework (direct mode, GLSim, integration tests)
-- `genvm-linter` — static analysis that catches contract errors before you deploy
+- `genvm-lint` (from the `genvm-linter` package) — static analysis that catches contract errors before you deploy
 
 Your project layout:
 
@@ -60,7 +70,7 @@ gltest.config.yaml  # Network and account configuration
 <Tabs items={['GLSim (no Docker)', 'GenLayer Studio (Docker)']}>
   <Tabs.Tab>
     ```bash
-    pip install genlayer-test[sim]
+    pip install 'genlayer-test[sim]'
     glsim --port 4000 --validators 5
     ```
 
@@ -175,7 +185,7 @@ Available fixtures: `direct_vm`, `direct_deploy`, `direct_alice`, `direct_bob`, 
 
 ### Make it intelligent
 
-Now add what no regular smart contract can do — access the web or call an LLM:
+Now add what no regular smart contract can do — call an LLM to make a decision on-chain:
 
 ```python
 # { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
@@ -183,30 +193,32 @@ Now add what no regular smart contract can do — access the web or call an LLM:
 from genlayer import *
 import json
 
-class PriceFeed(gl.Contract):
-    last_price: str
+class SentimentChecker(gl.Contract):
+    last_result: str
 
     def __init__(self):
-        self.last_price = "unknown"
+        self.last_result = ""
 
     @gl.public.write
-    def update_price(self, ticker: str) -> None:
+    def analyze(self, text: str) -> None:
         # Non-deterministic operations must run inside a function
         # passed to gl.eq_principle.* — this is how GenLayer reaches
         # consensus across validators that may get slightly different results.
-        def fetch() -> str:
-            data = gl.nondet.web.get(
-                f"https://api.coinbase.com/v2/prices/{ticker}-USD/spot"
+        def run():
+            result = gl.nondet.exec_prompt(
+                f'Classify the sentiment of this text as POSITIVE, NEGATIVE, or NEUTRAL. '
+                f'Text: "{text}". '
+                f'Respond ONLY with valid JSON: {{"sentiment": "<POSITIVE|NEGATIVE|NEUTRAL>"}}',
+                response_format="json"
             )
-            parsed = json.loads(data)
-            return json.dumps({"price": parsed["data"]["amount"]}, sort_keys=True)
+            return json.dumps(result, sort_keys=True)
 
-        result = gl.eq_principle.strict_eq(fetch)
-        self.last_price = json.loads(result)["price"]
+        raw = gl.eq_principle.strict_eq(run)
+        self.last_result = json.loads(raw)["sentiment"]
 
     @gl.public.view
-    def get_price(self) -> str:
-        return self.last_price
+    def get_result(self) -> str:
+        return self.last_result
 ```
 
 <Callout type="warning">
@@ -214,21 +226,13 @@ class PriceFeed(gl.Contract):
   Without it, validators may produce differently-ordered JSON and fail to reach consensus.
 </Callout>
 
-The key concept: `gl.eq_principle.strict_eq` tells GenLayer that all validators must
-return byte-identical results. Use this when output is constrained (JSON with fixed keys,
-booleans). For subjective outputs like summaries or classifications, use `prompt_comparative` instead.
+The key concept: `gl.eq_principle.strict_eq` tells GenLayer that all validators must return byte-identical results. It works best when output is tightly constrained — like a fixed JSON schema with a small set of possible values.
+
+For web data access (like fetching live prices), validators may get slightly different values depending on timing. See the [Price Oracle example](/developers/intelligent-contracts/equivalence-principle) in the Equivalence Principle docs for the correct pattern.
 
 → Deep dive: [Equivalence Principle](/developers/intelligent-contracts/equivalence-principle)
 
 </Steps>
-
----
-
-## Zero-setup alternative
-
-Don't want to install anything yet? Open [studio.genlayer.com](https://studio.genlayer.com) and
-load any built-in example. You can write, deploy, and call contracts directly in the browser —
-no local setup needed. You can also import any deployed contract by address to interact with it.
 
 ---
 
@@ -239,7 +243,6 @@ no local setup needed. You can also import any deployed contract by address to i
 - [Calling LLMs](/developers/intelligent-contracts/features/calling-llms) — `exec_prompt`, response formats, and choosing the right eq principle
 - [Web Access](/developers/intelligent-contracts/features/web-access) — `web.get` vs `web.render`, modes, and when to use each
 - [Prompt & Data Techniques](/developers/intelligent-contracts/crafting-prompts) — prompt patterns that maximize validator agreement
-- [Best Practices & Common Patterns](/developers/intelligent-contracts/security-and-best-practices/best-practices) — access control, storage patterns, common mistakes, upgrade patterns
 
 **Write proper tests**
 - [Testing](/developers/intelligent-contracts/testing) — direct mode, mocking web/LLM calls, integration tests

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -9,7 +9,7 @@ In other words, GenLayer is the first Intelligent Blockchain. Enabling smart con
 - **Ethereum is Trustless Applications,**<br />
 - **GenLayer is Trustless Decision-Making.**
 GenLayer's Intelligent Contracts can connect to the Internet, process natural language, and handle non-deterministic operations such as making subjective decisions, enabling a whole new generation of smart contract logic that is not possible under the limitations of current blockchain infrastructure.
-See some of the usecases [here](/understand-genlayer-protocol/typical-use-cases).
+See some of the use cases [here](/understand-genlayer-protocol/typical-use-cases).
 Protocols and applications that can **understand, learn, and adapt to real-world events.**
 ## Get Started
 <br/>

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,44 +1,41 @@
-import Image from 'next/image'
-import { Card, Cards } from 'nextra-theme-docs'
 import CustomCard from '../components/card'
+
 # Welcome to GenLayer 
 ## The Intelligence Layer of the Internet. 
-GenLayer is a new class of DLT capable of non deterministic operations through a dynamic consensus mechanism, by leveraging the [Jury Theorem](https://en.wikipedia.org/wiki/Condorcet%27s_jury_theorem) ("wisdom of the crowd") and [Schelling Point](https://en.wikipedia.org/wiki/Focal_point_(game_theory)) mechanics.
+
+GenLayer is a new class of DLT capable of non-deterministic operations through a dynamic consensus mechanism, by leveraging the [Jury Theorem](https://en.wikipedia.org/wiki/Condorcet%27s_jury_theorem) ("wisdom of the crowd") and [Schelling Point](https://en.wikipedia.org/wiki/Focal_point_(game_theory)) mechanics.
+
 In other words, GenLayer is the first Intelligent Blockchain. Enabling smart contracts to natively access the Internet and go beyond deterministic logic, to make subjective decisions.
+
 - **Bitcoin is Trustless Money,**<br />
 - **Ethereum is Trustless Applications,**<br />
 - **GenLayer is Trustless Decision-Making.**
+
 GenLayer's Intelligent Contracts can connect to the Internet, process natural language, and handle non-deterministic operations such as making subjective decisions, enabling a whole new generation of smart contract logic that is not possible under the limitations of current blockchain infrastructure.
+
 See some of the use cases [here](/understand-genlayer-protocol/typical-use-cases).
+
 Protocols and applications that can **understand, learn, and adapt to real-world events.**
+
 ## Get Started
+
 <br/>
-<div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: '1rem' }}>
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '1rem' }}>
   <CustomCard
     arrow
     title="Discover the Protocol"
     description="What GenLayer is, how Optimistic Democracy works, and what makes it different."
     href="/understand-genlayer-protocol"
   />
-  {/* <CustomCard
-    arrow
-    title="For Holders"
-    description="Step-by-step guides to building Intelligent Contracts using the Python-based GenLayer SDK.
-"
-    href="/users"
-  /> */}
+
   <CustomCard
     arrow
     title="For Developers"
     description="Build Intelligent Contracts in Python. Deploy to testnet or Studio."
     href="/developers/intelligent-contracts/quick-start"
   />
-  {/* <CustomCard
-    arrow
-    title="For Contributors"
-    description="Help in the mission to build the future of AI-powered smart contracts."
-    href="/contributors"
-  /> */}
+
   <CustomCard
     arrow
     title="For Validators"
@@ -46,8 +43,13 @@ Protocols and applications that can **understand, learn, and adapt to real-world
     href="/validators/setup-guide"
   />
 </div>
+
 ## Community and Careers
+
 **Need Help?**
+
 Join our vibrant community on [Discord](https://discord.gg/8Jm4v89VAu) or [Telegram](https://t.me/genlayer) to ask questions, share feedback, and showcase your GenLayer creations.
+
 **Looking to Build the Future with Us?**
+
 We're hiring! If blockchain and AI excite you, [explore our career opportunities](https://apply.workable.com/yeager-dot-a-i/) and help shape the future of decentralized applications.

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -40,7 +40,7 @@ Protocols and applications that can **understand, learn, and adapt to real-world
     arrow
     title="For Developers"
     description="Step-by-step guides to building Intelligent Contracts using the Python-based GenLayer SDK."
-    href="/developers"
+    href="/developers/intelligent-contracts/quick-start"
   />
   {/* <CustomCard
     arrow


### PR DESCRIPTION
## What

Adds a new Quick Start page for developers new to GenLayer.

## Why

Currently there is no single linear path from zero to a running 
contract. New developers land on the docs and have to piece together 
information from multiple pages (Development Setup, Your First Contract, 
Your First Intelligent Contract) without a clear starting point.

## Changes

- Add `pages/developers/intelligent-contracts/quick-start.mdx`
- Update `_meta.json` to show Quick Start first in the sidebar
- Update homepage to link directly to Quick Start

## Related

Related to #346 (point #9 — no clear onboarding path for new developers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Quick Start guide for Intelligent Contracts covering environment options, contract examples, testing, linting, deployment, Studio and CLI workflows, and next-step links.
  * Added a "Quick Start" metadata entry so the docs route is named accordingly.
  * Updated homepage hero text and the "For Developers" card to link directly to the new Quick Start guide; adjusted card layout and help/careers copy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->