### PR TITLE
fix: split testnet faucet into Asimov and Bradbury

### DIFF
--- a/pages/FAQ.mdx
+++ b/pages/FAQ.mdx
@@ -5,95 +5,94 @@ title: "FAQ"
 # FAQ
 
 <details>
-  <summary>1. What is GenLayer?</summary>
-  
-  GenLayer is an AI-native Layer 1 blockchain designed to run **Intelligent Contracts**—smart contracts enhanced with Large Language Models (LLMs)—enabling them to process natural language, fetch web data in real time, and execute data-driven logic.
+  <summary>What is GenLayer?</summary>
+
+  GenLayer is a blockchain where validator nodes powered by diverse AI models reach consensus on subjective decisions. It's built as an L2 on zkSync Elastic Chain, anchoring to Ethereum's security. Contracts on GenLayer — called **Intelligent Contracts** — can interpret language, process images, fetch live web data, and make subjective decisions. See [What is GenLayer](/understand-genlayer-protocol/what-is-genlayer).
 </details>
 
 <details>
-  <summary>2. How is GenLayer different from traditional blockchains?</summary>
+  <summary>How is GenLayer different from other blockchains?</summary>
 
-  Most blockchains rely solely on deterministic logic and external oracles to interact with off-chain data. **GenLayer integrates AI at the protocol level**, allowing on-chain contracts to directly interpret text prompts, perform complex computations, and adapt to real-world events without relying on external oracles.
+  Traditional smart contracts can only execute deterministic logic and rely on external oracles for off-chain data. GenLayer integrates AI at the protocol level — contracts natively access LLMs, the web, and image processing. No oracles, no intermediaries. See [What is GenLayer](/understand-genlayer-protocol/what-is-genlayer#how-it-compares).
 </details>
 
 <details>
-  <summary>3. What is “Optimistic Democracy” consensus?</summary>
+  <summary>What language are Intelligent Contracts written in?</summary>
 
-  **Optimistic Democracy** is GenLayer’s enhanced Delegated Proof of Stake (dPoS) mechanism. It randomly selects a **Lead-Validator** to process transactions and multiple **Co-Validators** to verify the results. The system is designed to handle non-deterministic (AI-driven) outputs securely by requiring a majority agreement.
+  **Python.** Intelligent Contracts are Python classes extending `gl.Contract`. No Solidity required. See [Your First Contract](/developers/intelligent-contracts/first-contract).
 </details>
 
 <details>
-  <summary>4. Why does GenLayer use Large Language Models (LLMs)?</summary>
+  <summary>What is Optimistic Democracy?</summary>
 
-  LLMs give Intelligent Contracts the ability to interpret and process complex human language, as well as to analyze data in ways traditional code-based smart contracts cannot. This opens up new use cases, such as AI-driven DAOs, predictive analytics, and autonomous oracles.
+  GenLayer's consensus mechanism. A leader validator executes the transaction and proposes a result. Other validators independently verify it and vote. If a majority agrees, the transaction is accepted. Anyone can appeal within a finality window, triggering re-evaluation by a larger validator set. See [How GenLayer Works](/understand-genlayer-protocol/optimistic-democracy-how-genlayer-works).
 </details>
 
 <details>
-  <summary>5. Can I still run normal, deterministic transactions on GenLayer?</summary>
+  <summary>How do validators handle non-deterministic AI results?</summary>
 
-  Absolutely. GenLayer supports **standard blockchain transactions** and deterministic logic alongside AI-driven logic. Developers can write regular smart contracts or Intelligent Contracts depending on their needs.
+  Since LLMs and web data produce varying outputs, GenLayer provides multiple strategies: strict equality (for deterministic operations), LLM-based comparison (validators compare outputs against criteria), and custom validation functions (developers define their own leader/validator logic). See [Non-determinism](/developers/intelligent-contracts/features/non-determinism).
 </details>
 
 <details>
-  <summary>6. Do I have to be an AI expert to build on GenLayer?</summary>
+  <summary>Can contracts process images?</summary>
 
-  Not necessarily. While some knowledge of AI or LLMs can help, GenLayer provides a **Python-based SDK** and user-friendly tools (like the GenLayer Studio) to simplify contract creation. You can harness AI capabilities without deep machine learning expertise.
+  Yes. Pass images to LLMs via `gl.nondet.exec_prompt(images=[...])`. Contracts can also capture web page screenshots with `gl.nondet.web.render(url, mode='screenshot')` and analyze them. See [Image Processing](/developers/intelligent-contracts/features/image-processing).
 </details>
 
 <details>
-  <summary>7. How do validators handle AI computation?</summary>
+  <summary>Can contracts send and receive GEN (native token)?</summary>
 
-  Each validator runs both **Validator Software** (for networking, block production, and transaction management) **and** an **AI Model Integration** via API. When a contract calls an AI-dependent function, the validator executes that function locally, **then** verifies the output through the consensus process.
+  Yes. Use `@gl.public.write.payable` to receive value, `gl.message.value` to access the amount sent, and `emit_transfer()` to send value to other contracts or EOAs. See [Value Transfers](/developers/intelligent-contracts/features/value-transfers).
 </details>
 
 <details>
-  <summary>8. What happens if validators disagree on an AI result?</summary>
+  <summary>Do I need to be an AI expert?</summary>
 
-  In **Optimistic Democracy**, disagreements trigger a **majority vote**. If a validator strongly believes the proposed result is incorrect, they can challenge or appeal the outcome within the **Finality Window**. An appeal bond is posted to discourage frivolous or malicious appeals.
+  No. The GenLayer SDK handles LLM calls and consensus. You write Python and call `gl.nondet.exec_prompt()` with a prompt. Validators handle model execution. GenLayer Studio provides a browser-based IDE for writing, deploying, and testing contracts.
 </details>
 
 <details>
-  <summary>9. How do I get started as a developer?</summary>
+  <summary>Can I run normal deterministic transactions?</summary>
 
-
-  1. Install the **GenLayer CLI** and set up your local environment.  
-  2. Explore the **GenLayer Studio** to write, deploy, and test your Intelligent Contracts.  
-  3. Check out the **genlayer-project-boilerplate** for end-to-end testing setups and best practices.  
-  4. Use **GenLayerJS** or other tools for front-end integration.
+  Yes. GenLayer fully supports deterministic logic — standard state updates, value transfers, and contract interactions all work without any AI components. You can mix deterministic and non-deterministic operations in the same contract.
 </details>
 
 <details>
-  <summary>10. Can I use any LLM provider?</summary>
+  <summary>What are ghost contracts?</summary>
 
-  GenLayer is designed to **integrate with multiple LLM providers**, such as GPT, LLaMA, and others. During the `genlayer init` process, you can configure your preferred LLM, including its API keys and model parameters. You can also customize or switch providers as needed.
+  Every Intelligent Contract has a corresponding ghost contract on the GenLayer Chain (EVM layer) at the same address. Ghost contracts hold the contract's GEN balance, relay transactions to consensus, and execute external messages. See [Ghost Contracts](/developers/intelligent-contracts/features/messages#ghost-contracts).
 </details>
 
 <details>
-  <summary>11. How is the network secured?</summary>
+  <summary>What can I build?</summary>
 
-  Security is driven by a **delegated staking** model plus the **Optimistic Democracy** consensus process:
-  - Token holders delegate **stake** to validators, incentivizing honest behavior.
-  - **Multi-Validator Verification** mitigates errors by checking each other’s results.
-  - **Appeals** provide a failsafe, penalizing dishonest validators via slashing.
+  Anything requiring subjective judgment: dispute resolution, prediction markets, insurance claims, content verification, compliance automation, AI-governed DAOs, and more. See [Use Cases](/understand-genlayer-protocol/typical-use-cases) and [projects building on GenLayer](https://portal.genlayer.foundation/#/).
 </details>
 
 <details>
-  <summary>12. What are the typical use cases for GenLayer?</summary>
+  <summary>How do I get started?</summary>
 
-
-  - **Prediction Markets**: AI-powered event outcomes  
-  - **Performance-Based Contracting**: Automatic escrow and payments tied to real-time metrics  
-  - **Network States**: Decentralized governance frameworks  
-  - **Dispute Resolution**: Low-cost, AI-driven arbitration  
-  - **AI-Driven DAOs**: Autonomous organizations that react to off-chain data  
+  1. Try [GenLayer Studio](https://studio.genlayer.com) in the browser — no setup needed
+  2. Or install the [GenLayer CLI](/api-references/genlayer-cli) for local development
+  3. Follow [Your First Contract](/developers/intelligent-contracts/first-contract)
+  4. Use [genlayer-js](/api-references/genlayer-js) or [genlayer-py](/api-references/genlayer-py) for app integration
 </details>
 
 <details>
-  <summary>13. How can I contribute to GenLayer?</summary>
+  <summary>How is the network secured?</summary>
 
-   You can:
-   - Join the community on **Discord** or **Telegram**  
-   - Contribute code and documentation in GenLayer’s GitHub repositories  
-   - Provide feedback and suggestions to improve the GenLayer ecosystem  
-   - Help grow the community by sharing GenLayer with potential developers and AI enthusiasts
+  Through delegated proof of stake and Optimistic Democracy:
+  - Token holders delegate stake to validators, incentivizing honest behavior
+  - Multiple validators independently verify each transaction
+  - Appeals provide a failsafe — dishonest validators get slashed
+  - The system anchors to Ethereum via zkSync for finality
+</details>
+
+<details>
+  <summary>How can I contribute?</summary>
+
+  - Join the community on [Discord](https://discord.gg/8Jm4v89VAu) or [Telegram](https://t.me/genlayer)
+  - Contribute to the [GitHub repositories](https://github.com/genlayerlabs)
+  - [We're hiring](https://x.com/GenLayer/jobs)
 </details>

--- a/pages/developers/intelligent-contracts/features.mdx
+++ b/pages/developers/intelligent-contracts/features.mdx
@@ -1,0 +1,28 @@
+import { Card, Cards } from 'nextra-theme-docs'
+
+# Intelligent Contract Features
+
+## Deterministic Features
+<Cards>
+  <Card title="🔢 Types" href="types" />
+  <Card title="💾 Storage" href="features/storage" />
+  <Card title="⚠️ Error Handling" href="features/error-handling" />
+  <Card title="🆕 Upgradability" href="features/upgradability" />
+  <Card title="💸 Value Transfers" href="features/value-transfers" />
+  <Card title="📨 Messages" href="features/messages" />
+  <Card title="🧠 Interacting with Intelligent Contracts" href="features/interacting-with-intelligent-contracts" />
+  <Card title="🔗 Interacting with EVM Contracts" href="features/interacting-with-evm-contracts" />
+  <Card title="⚡ Special Methods" href="features/special-methods" />
+  <Card title="➡️ Vector Storage" href="features/vector-storage" />
+  <Card title="🕵️ Debugging" href="features/debugging" />
+  <Card title="🎲 Random" href="features/random" />
+</Cards>
+
+## Non-Deterministic Features
+
+<Cards>
+  <Card title="🌀 Non-determinism" href="features/non-determinism" />
+  <Card title="🤖 Calling LLMs" href="features/calling-llms" />
+  <Card title="🖼️ Image Processing" href="features/image-processing" />
+  <Card title="🌏 Web Access" href="features/web-access" />
+</Cards>

--- a/pages/developers/intelligent-contracts/features/_meta.json
+++ b/pages/developers/intelligent-contracts/features/_meta.json
@@ -1,5 +1,4 @@
 {
-    "features": "Features",
     "storage": "Storage",
     "error-handling": "Error Handling",
     "upgradability": "Upgradability",
@@ -13,5 +12,6 @@
     "random": "Random",
     "non-determinism": "Non-determinism",
     "calling-llms": "Calling LLMs",
+    "image-processing": "Image Processing",
     "web-access": "Web Access"
 }

--- a/pages/developers/intelligent-contracts/features/features.mdx
+++ b/pages/developers/intelligent-contracts/features/features.mdx
@@ -6,12 +6,12 @@ import { Card, Cards } from 'nextra-theme-docs'
 <Cards>
   <Card title="🔢 Types" href="../types" />
   <Card title="💾 Storage" href="storage" />
-  <Card title="🐛 Error Handling" href="error-handling" />
+  <Card title="⚠️ Error Handling" href="error-handling" />
   <Card title="🆕 Upgradability" href="upgradability" />
   <Card title="💸 Value Transfers" href="value-transfers" />
   <Card title="📨 Messages" href="messages" />
   <Card title="🧠 Interacting with Intelligent Contracts" href="interacting-with-intelligent-contracts" />
-  <Card title="🐒 Interacting with EVM Contracts" href="interacting-with-evm-contracts" />
+  <Card title="🔗 Interacting with EVM Contracts" href="interacting-with-evm-contracts" />
   <Card title="⚡ Special Methods" href="special-methods" />
   <Card title="➡️ Vector Storage" href="vector-storage" />
   <Card title="🕵️ Debugging" href="debugging" />

--- a/pages/developers/intelligent-contracts/features/features.mdx
+++ b/pages/developers/intelligent-contracts/features/features.mdx
@@ -8,12 +8,13 @@ import { Card, Cards } from 'nextra-theme-docs'
   <Card title="💾 Storage" href="storage" />
   <Card title="🐛 Error Handling" href="error-handling" />
   <Card title="🆕 Upgradability" href="upgradability" />
-  <Card title="🪙 Balances" href="balances" />
+  <Card title="💸 Value Transfers" href="value-transfers" />
+  <Card title="📨 Messages" href="messages" />
   <Card title="🧠 Interacting with Intelligent Contracts" href="interacting-with-intelligent-contracts" />
   <Card title="🐒 Interacting with EVM Contracts" href="interacting-with-evm-contracts" />
+  <Card title="🕵️ Special Methods" href="special-methods" />
   <Card title="➡️ Vector Storage" href="vector-storage" />
   <Card title="🕵️ Debugging" href="debugging" />
-  <Card title="🕵️ Special Methods" href="special-methods" />
   <Card title="🎲 Random" href="random" />
 </Cards>
 

--- a/pages/developers/intelligent-contracts/features/features.mdx
+++ b/pages/developers/intelligent-contracts/features/features.mdx
@@ -4,7 +4,7 @@ import { Card, Cards } from 'nextra-theme-docs'
 
 ## Deterministic Features
 <Cards>
-  <Card title="😵‍💫 Types" href="../types" />
+  <Card title="🔢 Types" href="../types" />
   <Card title="💾 Storage" href="storage" />
   <Card title="🐛 Error Handling" href="error-handling" />
   <Card title="🆕 Upgradability" href="upgradability" />

--- a/pages/developers/intelligent-contracts/features/features.mdx
+++ b/pages/developers/intelligent-contracts/features/features.mdx
@@ -12,7 +12,7 @@ import { Card, Cards } from 'nextra-theme-docs'
   <Card title="📨 Messages" href="messages" />
   <Card title="🧠 Interacting with Intelligent Contracts" href="interacting-with-intelligent-contracts" />
   <Card title="🐒 Interacting with EVM Contracts" href="interacting-with-evm-contracts" />
-  <Card title="🕵️ Special Methods" href="special-methods" />
+  <Card title="⚡ Special Methods" href="special-methods" />
   <Card title="➡️ Vector Storage" href="vector-storage" />
   <Card title="🕵️ Debugging" href="debugging" />
   <Card title="🎲 Random" href="random" />

--- a/pages/developers/intelligent-contracts/features/image-processing.mdx
+++ b/pages/developers/intelligent-contracts/features/image-processing.mdx
@@ -67,5 +67,5 @@ result = gl.eq_principle.strict_eq(check_website_status)
 - **UI verification** — screenshot an app and verify it renders correctly
 
 <Callout type="info">
-  Image processing requires a vision-capable LLM model (e.g., GPT-4o, Claude Sonnet). Ensure your validator configuration includes a model that supports image inputs.
+  Image processing requires vision-capable LLM models. On the GenLayer network, validators handle model selection — your contract just sends images. In Studio running locally, ensure your configured validators use a model that supports image inputs (e.g., GPT-4o, Claude Sonnet).
 </Callout>

--- a/pages/developers/intelligent-contracts/features/image-processing.mdx
+++ b/pages/developers/intelligent-contracts/features/image-processing.mdx
@@ -67,5 +67,5 @@ result = gl.eq_principle.strict_eq(check_website_status)
 - **UI verification** — screenshot an app and verify it renders correctly
 
 <Callout type="info">
-  Image processing requires vision-capable LLM models. On the GenLayer network, validators handle model selection — your contract just sends images. In Studio running locally, ensure your configured validators use a model that supports image inputs (e.g., GPT-4o, Claude Sonnet).
+  Image processing requires vision-capable LLM models. On the GenLayer network, validators handle model selection — your contract just sends images. In Studio running locally, ensure your configured validators use a model that supports image inputs (e.g., GPT-5, Claude Sonnet).
 </Callout>

--- a/pages/developers/intelligent-contracts/features/image-processing.mdx
+++ b/pages/developers/intelligent-contracts/features/image-processing.mdx
@@ -20,11 +20,10 @@ class ReceiptVerifier(gl.Contract):
     @gl.public.write
     def verify_receipt(self, image_data: bytes, expected_amount: str) -> None:
         def leader_fn():
-            image = gl.nondet.Image(raw=image_data, pil=None)
             return gl.nondet.exec_prompt(
                 f"Does this receipt show a payment of {expected_amount}? "
                 "Respond as JSON: {{\"matches\": true/false, \"actual_amount\": \"...\"}}",
-                images=[image],
+                images=[image_data],  # accepts raw bytes directly
                 response_format="json",
             )
 
@@ -38,7 +37,7 @@ class ReceiptVerifier(gl.Contract):
         self.verified = result["matches"]
 ```
 
-The `images` parameter accepts a sequence of `bytes` or `gl.nondet.Image` objects.
+The `images` parameter accepts a sequence of raw `bytes` (e.g., PNG/JPEG data) or `gl.nondet.Image` objects.
 
 ## Capturing Screenshots from the Web
 

--- a/pages/developers/intelligent-contracts/features/image-processing.mdx
+++ b/pages/developers/intelligent-contracts/features/image-processing.mdx
@@ -1,0 +1,72 @@
+import { Callout } from "nextra-theme-docs";
+
+# Image Processing
+
+Intelligent Contracts can process images through LLMs — pass screenshots, photos, or any visual data alongside a prompt for analysis.
+
+## Sending Images to LLMs
+
+Use the `images` parameter in `gl.nondet.exec_prompt()`:
+
+```python
+from genlayer import *
+
+class ReceiptVerifier(gl.Contract):
+    verified: bool
+
+    def __init__(self):
+        self.verified = False
+
+    @gl.public.write
+    def verify_receipt(self, image_data: bytes, expected_amount: str) -> None:
+        def leader_fn():
+            image = gl.nondet.Image(raw=image_data, pil=None)
+            return gl.nondet.exec_prompt(
+                f"Does this receipt show a payment of {expected_amount}? "
+                "Respond as JSON: {{\"matches\": true/false, \"actual_amount\": \"...\"}}",
+                images=[image],
+                response_format="json",
+            )
+
+        def validator_fn(leaders_res) -> bool:
+            if not isinstance(leaders_res, gl.vm.Return):
+                return False
+            my_result = leader_fn()
+            return my_result["matches"] == leaders_res.calldata["matches"]
+
+        result = gl.vm.run_nondet_unsafe(leader_fn, validator_fn)
+        self.verified = result["matches"]
+```
+
+The `images` parameter accepts a sequence of `bytes` or `gl.nondet.Image` objects.
+
+## Capturing Screenshots from the Web
+
+Combine [web access](/developers/intelligent-contracts/features/web-access) with image processing to screenshot a webpage and analyze it:
+
+```python
+def check_website_status():
+    url = "https://example.com/status-page"
+    screenshot = gl.nondet.web.render(url, mode='screenshot')
+    
+    return gl.nondet.exec_prompt(
+        "Is this status page showing all systems operational? "
+        "Respond as JSON: {{\"all_operational\": true/false}}",
+        images=[screenshot],
+        response_format="json",
+    )
+
+result = gl.eq_principle.strict_eq(check_website_status)
+```
+
+## Use Cases
+
+- **Visual evidence verification** — insurance claims with photo proof, damage assessment
+- **Document analysis** — receipts, invoices, certificates
+- **Web monitoring** — screenshot a page and verify its content matches expectations
+- **Brand & content compliance** — check if visual content meets guidelines
+- **UI verification** — screenshot an app and verify it renders correctly
+
+<Callout type="info">
+  Image processing requires a vision-capable LLM model (e.g., GPT-4o, Claude Sonnet). Ensure your validator configuration includes a model that supports image inputs.
+</Callout>

--- a/pages/developers/intelligent-contracts/features/value-transfers.mdx
+++ b/pages/developers/intelligent-contracts/features/value-transfers.mdx
@@ -152,7 +152,10 @@ graph TD
 |---|---|
 | Studio (Localnet) | Built-in faucet — 💧 button in the account selector |
 | Studionet | Built-in faucet — 💧 button in the account selector |
-| Testnet | [testnet-faucet.genlayer.foundation](https://testnet-faucet.genlayer.foundation/) |
+| Testnet Asimov | [testnet-faucet.genlayer.foundation](https://testnet-faucet.genlayer.foundation/) |
+| Testnet Bradbury | [testnet-faucet.genlayer.foundation](https://testnet-faucet.genlayer.foundation/) |
+
+See [Networks](/developers/networks) for full details on each environment.
 
 ## Calling Payable Methods from JavaScript
 

--- a/pages/developers/intelligent-contracts/first-contract.mdx
+++ b/pages/developers/intelligent-contracts/first-contract.mdx
@@ -9,7 +9,7 @@ First of all, you need to place a magic comment with the version of GenVM you wi
 ```py
 # { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
 ```
-It is similar to Solidity's `pragma solidity`, and `test` after a colon is a version. When GenLayer releases, it will be changed to some exact hash of a version, which will be frozen forever.
+It is similar to Solidity's `pragma solidity`. The hash after the colon identifies the exact version of the Python runtime to use, ensuring your contract always runs against the same environment.
 
 ### Importing the Standard Library
 After the version comment, you can import the GenLayer standard library:

--- a/pages/developers/intelligent-contracts/introduction.mdx
+++ b/pages/developers/intelligent-contracts/introduction.mdx
@@ -74,32 +74,10 @@ Development of Intelligent Contracts leverages Python's robust ecosystem, provid
 
 The platform supports the data structures needed to handle complex business logic and requirements.
 
-## Challenges and Mitigations
+## Trade-offs
 
-### Non-Deterministic Operations
-**Challenge**
+Intelligent Contracts introduce non-determinism and external dependencies that traditional smart contracts avoid. Key considerations:
 
-The primary challenge in handling non-deterministic operations is maintaining consistency across multiple validators when operations may naturally produce varying results. This is particularly evident when dealing with LLM outputs or real-time data processing.
-
-**Mitigation**
-
-To address this, GenLayer provides the Equivalence Principle as a flexible framework for developers to decide how the validators will try to reach consensus. This system allows for both strict output matching and more nuanced validation approaches where validators can assess results within acceptable parameters, ensuring reliable contract execution even with non-deterministic elements.
-
-### External Data Reliability
-**Challenge**
-
-Integrating external data sources introduces potential points of failure and data inconsistency risks that must be carefully managed. External APIs may experience downtime, return inconsistent results, or become deprecated over time.
-
-**Mitigation**
-
-To combat these challenges, Intelligent Contracts employ a robust multi-validator verification system where multiple independent validators must confirm external data integrity.
-
-### Performance Considerations
-
-**Challenge**
-
-The integration of LLM operations and complex data processing can introduce significant computational overhead, potentially impacting contract execution speed and cost efficiency.
-
-**Mitigation**
-
-To tackle these performance challenges, GenLayer implements optimized validation processes that balance thoroughness with efficiency. The platform provides configurable consensus mechanisms that allow developers to fine-tune the validation process based on their specific needs, whether prioritizing speed or verification thoroughness.
+- **Non-deterministic outputs** — LLM responses and web data vary across validators. The [Equivalence Principle](/developers/intelligent-contracts/features/non-determinism) lets you define how validators compare results to reach consensus.
+- **External data reliability** — Web sources can be inconsistent or unavailable. Multiple validators independently fetch and cross-validate data as part of [Optimistic Democracy](/understand-genlayer-protocol/optimistic-democracy-how-genlayer-works).
+- **Compute cost** — LLM calls and web requests add latency and cost compared to purely deterministic contracts. Design contracts to minimize non-deterministic calls where possible.

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -2,68 +2,44 @@ import Image from 'next/image'
 import { Card, Cards } from 'nextra-theme-docs'
 import CustomCard from '../components/card'
 
-# Welcome to GenLayer 
-## The Intelligence Layer of the Internet. 
+## Trust Infrastructure for the AI Age
 
-GenLayer is a new class of DLT capable of non deterministic operations through a dynamic consensus mechanism, by leveraging the [Jury Theorem](https://en.wikipedia.org/wiki/Condorcet%27s_jury_theorem) ("wisdom of the crowd") and [Schelling Point](https://en.wikipedia.org/wiki/Focal_point_(game_theory)) mechanics.
+GenLayer is a blockchain where validator nodes powered by diverse AI models reach consensus on subjective decisions — a synthetic jurisdiction on-chain.
 
+Intelligent Contracts interpret language, process unstructured data, and pull live web inputs. No oracles, no intermediaries.
 
-In other words, GenLayer is the first Intelligent Blockchain. Enabling smart contracts to natively access the Internet and go beyond deterministic logic, to make subjective decisions.
+- **Bitcoin** — Trustless Money
+- **Ethereum** — Trustless Computation
+- **GenLayer** — Trustless Decision-Making
 
-- **Bitcoin is Trustless Money,**<br />
-- **Ethereum is Trustless Applications,**<br />
-- **GenLayer is Trustless Decision-Making.**
-
-GenLayer's Intelligent Contracts can connect to the Internet, process natural language, and handle non-deterministic operations such as making subjective decisions, enabling a whole new generation of smart contract logic that is not possible under the limitations of current blockchain infrastructure.
-
-See some of the usecases [here](/understand-genlayer-protocol/typical-use-cases).
-
-Protocols and applications that can **understand, learn, and adapt to real-world events.**
+Explore [typical use cases](/understand-genlayer-protocol/typical-use-cases) or jump straight into building.
 
 ## Get Started
+
 <br/>
-<div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: '1rem' }}>
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: '1rem' }}>
   <CustomCard
     arrow
     title="Discover the Protocol"
-    description="An introduction to GenLayer and its core functionalities. Learn what sets GenLayer apart."
-    href="/about-genlayer"
+    description="What GenLayer is, how Optimistic Democracy works, and what makes it different."
+    href="/understand-genlayer-protocol"
   />
-  {/* <CustomCard
-    arrow
-    title="For Holders"
-    description="Step-by-step guides to building Intelligent Contracts using the Python-based GenLayer SDK.
-"
-    href="/users"
-  /> */}
   <CustomCard
     arrow
     title="For Developers"
-    description="Step-by-step guides to building Intelligent Contracts using the Python-based GenLayer SDK."
+    description="Build Intelligent Contracts in Python. Deploy to testnet or Studio."
     href="/developers"
   />
-  {/* <CustomCard
-    arrow
-    title="For Contributors"
-    description="Help in the mission to build the future of AI-powered smart contracts."
-    href="/contributors"
-  /> */}
   <CustomCard
     arrow
     title="For Validators"
-    description="Detailed instructions on running validator nodes and actively participating in the GenLayer network."
+    description="Run a validator node and participate in the GenLayer network."
     href="/validators/setup-guide"
   />
 </div>
 
-
-
-
 ## Community and Careers
-**Need Help?**
 
-Join our vibrant community on [Discord](https://discord.gg/8Jm4v89VAu) or [Telegram](https://t.me/genlayer) to ask questions, share feedback, and showcase your GenLayer creations.
+Join the community on [Discord](https://discord.gg/8Jm4v89VAu) or [Telegram](https://t.me/genlayer) to ask questions, share feedback, and showcase your builds.
 
-**Looking to Build the Future with Us?**
-
-We're hiring! If blockchain and AI excite you, [explore our career opportunities](https://apply.workable.com/yeager-dot-a-i/) and help shape the future of decentralized applications.
+We're hiring — [see open roles](https://x.com/GenLayer/jobs).

--- a/pages/understand-genlayer-protocol/_meta.json
+++ b/pages/understand-genlayer-protocol/_meta.json
@@ -1,9 +1,6 @@
 {
-  "what-makes-genlayer-different": "What Makes GenLayer Different?",
-  "optimistic-democracy-how-genlayer-works": "Optimistic Democracy: How GenLayer Works",
-  "typical-use-cases": "Typical Use Cases",
-  "why-we-are-building-genlayer": "Why We Are Building GenLayer?",
-  "who-is-genlayer-for": "Who is GenLayer for?",
-  "what-are-intelligent-contracts": "What Are Intelligent Contracts?",
+  "what-is-genlayer": "What is GenLayer",
+  "optimistic-democracy-how-genlayer-works": "How GenLayer Works",
+  "typical-use-cases": "Use Cases",
   "core-concepts": "Core Concepts"
 }

--- a/pages/understand-genlayer-protocol/optimistic-democracy-how-genlayer-works.mdx
+++ b/pages/understand-genlayer-protocol/optimistic-democracy-how-genlayer-works.mdx
@@ -1,19 +1,47 @@
-# Optimistic Democracy: How GenLayer Works
+import { Callout } from "nextra-theme-docs";
 
-<img src="/studio/diagram main.jpg" alt="GenLayer Optimistic Democracy Diagram" />
+# How GenLayer Works
 
-Optimistic Democracy is GenLayer's consensus mechanism, rooted in [Condorcet's Jury Theorem](https://jury-theorem.genlayer.com/) (click the link to check out our interactive model), which affirms that collective decision-making becomes more accurate as independent validators vote. The process unfolds in distinct phases:
+## Optimistic Democracy
 
-1. **Transaction Submission**: A user sends a transaction to the GenLayer network.
+GenLayer uses **Optimistic Democracy** for consensus — a mechanism where validators running diverse AI models independently evaluate transactions and vote on outcomes. It applies [Condorcet's Jury Theorem](https://en.wikipedia.org/wiki/Condorcet%27s_jury_theorem): a group of independent reasoners is more likely to reach the correct answer than any individual.
 
-2. **Leader Proposes Result**: A validator is randomly chosen as the Leader validator. It processes the transaction and proposes a result.
+Transactions are accepted if a majority of validators agree. Anyone can appeal an accepted result, triggering re-evaluation by a new, larger validator set. This process can escalate through multiple rounds until a final decision is reached.
 
-3. **Validators Recompute**: A committee of validators re-compute the transaction. They either approve or deny based on whether the output aligns with the Leader's result (i.e. is <b>equivalent</b>).
+## Transaction Lifecycle
 
-4. **Result Accepted**: Once a majority approves, the result is provisionally accepted.
+Every transaction moves through these stages:
 
-5. **Appeal**: If any participant disputes the outcome, they can appeal within the Finality Window by posting a bond.
+1. **Pending** — queued, waiting to be picked up
+2. **Proposing** — a leader validator executes the contract and proposes a result
+3. **Committing** — other validators execute independently and submit encrypted votes
+4. **Leader Revealing** — the leader reveals execution data and decryption keys
+5. **Revealing** — validators reveal their votes
+6. **Accepted** — majority consensus reached; transaction enters the appeal window
+7. **Finalized** — appeal window closed, result is permanent and irreversible
 
-6. **Additional Validation (If Appealed)**: A new set of validators may be chosen to re-evaluate the transaction. If the appeal is valid, they reward the appellant. Otherwise, the bond is forfeited.
+If consensus is not reached, the transaction may be marked **Undetermined** or rotate to a new leader.
 
-7. **Final Decision**: After all appeals are resolved, the outcome becomes final.
+See [Transaction Execution](/understand-genlayer-protocol/core-concepts/transactions/transaction-execution) for the full state machine.
+
+## Non-Determinism and Consensus
+
+Because Intelligent Contracts use LLMs and web data, validators may produce different outputs for the same input. GenLayer provides several strategies for reaching consensus on non-deterministic results:
+
+- **Strict equality** — all validators must produce the exact same output (for deterministic operations)
+- **LLM-based comparison** — an LLM compares validator outputs against developer-defined criteria
+- **Custom validation** — developers write explicit leader/validator function pairs with full control over consensus logic
+
+See [Non-determinism](/developers/intelligent-contracts/features/non-determinism) for implementation details.
+
+## Appeals and Finality
+
+After a transaction is accepted, it enters a **finality window** during which anyone can appeal the result.
+
+- An appeal triggers a new round with a fresh, larger validator set
+- Appeals can escalate through multiple rounds
+- The final round's decision is binding
+
+Once the finality window closes without appeal (or after the final appeal round), the transaction is **finalized** — permanent and irreversible.
+
+See [Appeal Process](/understand-genlayer-protocol/core-concepts/optimistic-democracy/appeal-process) and [Finality](/understand-genlayer-protocol/core-concepts/optimistic-democracy/finality) for details.

--- a/pages/understand-genlayer-protocol/typical-use-cases.mdx
+++ b/pages/understand-genlayer-protocol/typical-use-cases.mdx
@@ -43,6 +43,10 @@ DAOs where proposals are written in natural language, evaluated against real-tim
 
 Real-time screening against sanctions lists, KYC/AML requirements, and changing regulations. Contracts read authoritative sources directly — no manual updates needed.
 
+## Insurance
+
+Parametric and evidence-based insurance where claims are evaluated by AI validators. Contracts fetch weather data, flight statuses, or photographic evidence to assess claims and trigger payouts automatically — no adjusters, no weeks of waiting.
+
 ## Argumentation & Debate Markets
 
 Structured debates where participants stake positions and AI consensus determines outcomes — a new primitive for information markets.

--- a/pages/understand-genlayer-protocol/typical-use-cases.mdx
+++ b/pages/understand-genlayer-protocol/typical-use-cases.mdx
@@ -1,20 +1,62 @@
-# Typical Use Cases
+# Use Cases
 
-- **Prediction Markets**: Power decentralized trading on future events. Applications include financial market forecasting, sports betting, and entertainment predictions.
+GenLayer enables applications that require subjective judgment — decisions that traditional smart contracts can't make because they need to interpret language, evaluate evidence, or assess quality.
 
-- **Performance-Based Contracting**: Automate escrows and payments contingent on verified performance metrics. Intelligent Contracts can track deliverables in real-time and instantly release funds.
+## Dispute Resolution
 
-- **Network States**: Launch decentralized governance frameworks for Network States, opening new horizons in collaborative decision-making and self-regulation.
+AI validators evaluate evidence and deliver verdicts in minutes. Applies to:
 
-- **Dispute Resolution**: It will serve as a decentralized, AI-driven arbitration system. Compared to conventional legal routes, it will reduce costs and expedite case handling.
+- **Agentic commerce** — AI agents transacting autonomously ([ERC-8183](https://eips.ethereum.org/EIPS/eip-8183)) need trustless arbitration for SLA compliance, delivery verification, service quality
+- **Chargebacks** — buyer/seller disputes resolved by analyzing shipping records, communication logs, and transaction history
+- **Freelance & gig work** — was the deliverable satisfactory? AI consensus replaces subjective back-and-forth
 
-- **AI-Driven DAOs**: Form next-gen decentralized autonomous organizations managed by AI algorithms. Empower real-time governance and data-informed investments.
+## Rule & Constitution Verification
 
-For more potential applications, see **Build with GenLayer**.
+Check whether something meets a set of criteria defined in natural language:
 
-### Autonomous Agents
-AI-powered agents that transact, govern, and settle decisions at machine speed — operating autonomously within enforceable on-chain rules.
+- Does a new prediction market meet listing guidelines?
+- Does a DAO proposal comply with the organization's charter?
+- Does a content submission follow community standards?
+- Does a transaction comply with regulatory requirements?
 
----
+This is a foundational primitive — many applications are instances of "evaluate X against rules Y."
 
-Ready to build? Start with the [developer guide](/developers/intelligent-contracts/first-contract).
+## Prediction Markets
+
+Markets that resolve automatically by fetching outcomes from primary sources. No centralized oracle or authority needed.
+
+→ [Example contract](/developers/intelligent-contracts/examples/prediction)
+
+## Social Content Verification
+
+AI validators assess content quality, detect plagiarism, and distribute rewards based on originality and engagement. Replaces centralized content moderation with consensus-driven evaluation.
+
+## Code & Work Quality Assurance
+
+Staked submissions where reviewers are economically incentivized to find issues. AI validators assess code quality, deliverable completeness, or compliance with specifications.
+
+## AI-Governed Organizations
+
+DAOs where proposals are written in natural language, evaluated against real-time data, and executed automatically when conditions align.
+
+## Compliance Automation
+
+Real-time screening against sanctions lists, KYC/AML requirements, and changing regulations. Contracts read authoritative sources directly — no manual updates needed.
+
+## Argumentation & Debate Markets
+
+Structured debates where participants stake positions and AI consensus determines outcomes — a new primitive for information markets.
+
+## What Makes These Possible
+
+All of these share a common pattern: they require **subjective judgment** that traditional smart contracts can't perform.
+
+GenLayer's Intelligent Contracts can:
+- Fetch and interpret live web data
+- Process natural language and unstructured inputs
+- Make subjective decisions through multi-validator AI consensus
+- Execute outcomes on-chain with full finality
+
+See [projects building on GenLayer](https://portal.genlayer.foundation/#/) for live examples.
+
+[Start building →](/developers/intelligent-contracts/first-contract)

--- a/pages/understand-genlayer-protocol/typical-use-cases.mdx
+++ b/pages/understand-genlayer-protocol/typical-use-cases.mdx
@@ -12,5 +12,9 @@
 
 For more potential applications, see **Build with GenLayer**.
 
-## Ready to Build on GenLayer?
-Whether you're looking to dive into Python-based smart contracts or explore AI-driven solutions, GenLayer provides the ideal foundation. Explore our [Developer Docs](https://docs.genlayer.com/developers) to start building.
+### Autonomous Agents
+AI-powered agents that transact, govern, and settle decisions at machine speed — operating autonomously within enforceable on-chain rules.
+
+---
+
+Ready to build? Start with the [developer guide](/developers/intelligent-contracts/first-contract).

--- a/pages/understand-genlayer-protocol/what-are-intelligent-contracts.mdx
+++ b/pages/understand-genlayer-protocol/what-are-intelligent-contracts.mdx
@@ -1,20 +1,5 @@
-## What Are Intelligent Contracts?
+import { Callout } from "nextra-theme-docs";
 
-Intelligent Contracts are AI-powered smart contracts designed to leverage Large Language Models (LLMs) for real-time web data retrieval and natural language processing. Unlike traditional smart contracts—limited by deterministic code and external oracles—Intelligent Contracts adapt their logic based on live data and evolving conditions. By natively integrating AI at the protocol level, Intelligent Contracts on GenLayer can understand and respond to complex, real-world scenarios, unlocking a new class of decentralized applications.
+# What Are Intelligent Contracts?
 
-<img src="/studio/evolution IC.jpg" alt="Evolution of Intelligent Contracts" width="100%" />
-
-| **Feature**               | **Traditional Smart Contracts**                                                      | **Intelligent Contracts**                                                                    |
-|---------------------------|--------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| **Definition**            | Self-executing blockchain programs with terms defined in code                       | AI-driven contracts that access web data and process natural language in real time           |
-| **Capabilities**          | Executes predefined on-chain actions based on code logic                            | Executes on-chain actions, can interpret external data, perform AI-driven reasoning, etc.    |
-| **Language Understanding**| Limited to code-based commands                                                       | Understands and acts on human-readable text prompts (natural language)                       |
-| **Web Data Access**       | Depends on external oracles for off-chain data                                       | Integrates directly with real-time web data, removing the need for external oracles          |
-| **Data Handling**         | Can only process data already on-chain                                               | Fetches and utilizes off-chain data (APIs, market info, web resources, etc.)                 |
-| **Programming Language**  | Often uses specialized blockchain languages (e.g. Solidity)                          | Generally Python-based in GenLayer, making development more accessible to a broader audience |
-| **Ease of Development**   | Requires specialized blockchain knowledge and tooling                                | Accessible via familiar languages (Python) and the GenLayer Studio developer experience       |
-| **Flexibility**           | Executes static operations based on predefined logic                                | Can adapt in real time to changing conditions, offering AI-driven functionality              |
-| **Consensus Mechanism**   | Relies on standard blockchain consensus (e.g., Proof of Stake, Proof of Work)        | Utilizes Optimistic Democracy for deterministic and non-deterministic contract outputs        |
-| **Use Cases**             | Typically restricted to basic on-chain logic like token transfers or deterministic dApps | Enables advanced apps like AI-driven DAOs, predictive analytics, autonomous oracles, etc. |
-
-By embedding AI-driven capabilities into the core of the blockchain, Intelligent Contracts deliver real-time adaptability, broader functionality, and deeper integration with the external world—significantly expanding the scope of what decentralized applications can achieve on GenLayer.
+This page has moved to [What is GenLayer](/understand-genlayer-protocol/what-is-genlayer).

--- a/pages/understand-genlayer-protocol/what-is-genlayer.mdx
+++ b/pages/understand-genlayer-protocol/what-is-genlayer.mdx
@@ -23,8 +23,11 @@ Fetch live web data directly on-chain. Contracts can read websites, call APIs, a
 ### Natural Language Processing
 Interpret human-readable inputs via LLMs. Contracts can analyze text, extract meaning, and make decisions based on qualitative criteria.
 
+### Image & Visual Processing
+Pass images to LLMs for analysis — screenshot a webpage and verify its content, check visual evidence for claims, analyze receipts or documents. Contracts can capture screenshots via `gl.nondet.web.render()` and send them to LLMs via `gl.nondet.exec_prompt(images=[...])`.
+
 ### Unstructured Data
-Process text, images, and qualitative evidence. Handle real-world complexity that traditional smart contracts cannot.
+Process text, images, audio transcripts, and qualitative evidence. Handle real-world complexity that traditional smart contracts cannot.
 
 ## How It Compares
 
@@ -33,7 +36,7 @@ Process text, images, and qualitative evidence. Handle real-world complexity tha
 | **Language** | Solidity, Rust | Python |
 | **Data sources** | On-chain only (or oracles) | On-chain + live web data |
 | **Decision logic** | Deterministic only | Deterministic + subjective |
-| **AI integration** | Not possible | Native LLM access |
+| **AI integration** | Not possible | Native LLM access (text + images) |
 | **Consensus** | All nodes must agree on exact output | Validators assess equivalence of results |
 
 ## Architecture: Two Layers

--- a/pages/understand-genlayer-protocol/what-is-genlayer.mdx
+++ b/pages/understand-genlayer-protocol/what-is-genlayer.mdx
@@ -1,0 +1,79 @@
+import { Callout } from "nextra-theme-docs";
+
+# What is GenLayer
+
+## Trust Infrastructure for the AI Age
+
+GenLayer is a blockchain where validator nodes powered by diverse AI models reach consensus on subjective decisions — a synthetic jurisdiction on-chain.
+
+Intelligent Contracts interpret language, process unstructured data, and pull live web inputs. No oracles, no intermediaries.
+
+- **Bitcoin** — Trustless Money
+- **Ethereum** — Trustless Computation
+- **GenLayer** — Trustless Decision-Making
+
+## What Intelligent Contracts Can Do
+
+### Subjective Decisions
+Evaluate context and nuance. Turn judgment calls into enforceable on-chain outcomes — content moderation, claim assessment, quality evaluation.
+
+### Internet Access
+Fetch live web data directly on-chain. Contracts can read websites, call APIs, and verify real-world information without oracles or intermediaries.
+
+### Natural Language Processing
+Interpret human-readable inputs via LLMs. Contracts can analyze text, extract meaning, and make decisions based on qualitative criteria.
+
+### Unstructured Data
+Process text, images, and qualitative evidence. Handle real-world complexity that traditional smart contracts cannot.
+
+## How It Compares
+
+| Feature | Traditional Smart Contracts | Intelligent Contracts |
+|---|---|---|
+| **Language** | Solidity, Vyper | Python |
+| **Data sources** | On-chain only (or oracles) | On-chain + live web data |
+| **Decision logic** | Deterministic only | Deterministic + subjective |
+| **AI integration** | Not possible | Native LLM access |
+| **Consensus** | All nodes must agree on exact output | Validators assess equivalence of results |
+
+## Architecture: Two Layers
+
+GenLayer operates as two integrated layers:
+
+**GenLayer Chain** — an EVM-compatible L2 (zkSync Elastic Chain). Holds account balances via ghost contracts, handles standard Ethereum operations (`eth_*` methods), and anchors to Ethereum's security model.
+
+**GenVM** — the execution environment for Intelligent Contracts. A Python runtime with native access to LLMs, web data, and non-deterministic operations.
+
+Every Intelligent Contract has a corresponding **ghost contract** on the chain layer at the same address. Ghost contracts hold the contract's GEN balance, relay transactions to consensus, and execute external messages. See [Messages](/developers/intelligent-contracts/features/messages#ghost-contracts) for details.
+
+Transactions enter via `addTransaction` on the chain layer. GenVM executes the contract logic. Results settle back on-chain.
+
+## Develop in Python
+
+Intelligent Contracts are Python classes extending `gl.Contract`:
+
+```python
+from genlayer import *
+
+class PredictionMarket(gl.Contract):
+    resolution: str
+
+    def __init__(self, question: str):
+        self.question = question
+        self.resolution = ""
+
+    @gl.public.write
+    def resolve(self) -> None:
+        result = gl.eq_principle.call_llm(
+            prompt=f"Has this event occurred? {self.question}",
+        )
+        self.resolution = result
+
+    @gl.public.view
+    def get_resolution(self) -> str:
+        return self.resolution
+```
+
+Full SDK available: [genlayer-js](/api-references/genlayer-js) (TypeScript), [genlayer-py](/api-references/genlayer-py) (Python), [CLI](/api-references/genlayer-cli).
+
+[Get started →](/developers/intelligent-contracts/first-contract)

--- a/pages/understand-genlayer-protocol/what-is-genlayer.mdx
+++ b/pages/understand-genlayer-protocol/what-is-genlayer.mdx
@@ -30,7 +30,7 @@ Process text, images, and qualitative evidence. Handle real-world complexity tha
 
 | Feature | Traditional Smart Contracts | Intelligent Contracts |
 |---|---|---|
-| **Language** | Solidity, Vyper | Python |
+| **Language** | Solidity, Rust | Python |
 | **Data sources** | On-chain only (or oracles) | On-chain + live web data |
 | **Decision logic** | Deterministic only | Deterministic + subjective |
 | **AI integration** | Not possible | Native LLM access |
@@ -42,7 +42,7 @@ GenLayer operates as two integrated layers:
 
 **GenLayer Chain** — an EVM-compatible L2 (zkSync Elastic Chain). Holds account balances via ghost contracts, handles standard Ethereum operations (`eth_*` methods), and anchors to Ethereum's security model.
 
-**GenVM** — the execution environment for Intelligent Contracts. A Python runtime with native access to LLMs, web data, and non-deterministic operations.
+**GenVM** — the execution environment for Intelligent Contracts. A WebAssembly-based VM (built on [Wasmtime](https://wasmtime.dev)) that runs a Python interpreter with native access to LLMs, web data, and non-deterministic operations. Can also execute compiled native code.
 
 Every Intelligent Contract has a corresponding **ghost contract** on the chain layer at the same address. Ghost contracts hold the contract's GEN balance, relay transactions to consensus, and execute external messages. See [Messages](/developers/intelligent-contracts/features/messages#ghost-contracts) for details.
 
@@ -53,25 +53,44 @@ Transactions enter via `addTransaction` on the chain layer. GenVM executes the c
 Intelligent Contracts are Python classes extending `gl.Contract`:
 
 ```python
+# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
 from genlayer import *
+import json
 
-class PredictionMarket(gl.Contract):
-    resolution: str
+class WizardOfCoin(gl.Contract):
+    has_coin: bool
 
-    def __init__(self, question: str):
-        self.question = question
-        self.resolution = ""
+    def __init__(self):
+        self.has_coin = True
 
     @gl.public.write
-    def resolve(self) -> None:
-        result = gl.eq_principle.call_llm(
-            prompt=f"Has this event occurred? {self.question}",
-        )
-        self.resolution = result
+    def ask_for_coin(self, request: str) -> None:
+        if not self.has_coin:
+            raise gl.vm.UserError("I don't have a coin!")
+
+        prompt = f"""
+        You are a wizard guarding a gold coin.
+        An adventurer says: {request}
+        Should you give them the coin?
+        Respond as JSON: {{"give_coin": true/false}}
+        """
+
+        def leader_fn():
+            return gl.nondet.exec_prompt(prompt, response_format="json")
+
+        def validator_fn(leaders_res) -> bool:
+            if not isinstance(leaders_res, gl.vm.Return):
+                return False
+            my_result = leader_fn()
+            return my_result["give_coin"] == leaders_res.calldata["give_coin"]
+
+        result = gl.vm.run_nondet_unsafe(leader_fn, validator_fn)
+        if result["give_coin"]:
+            self.has_coin = False
 
     @gl.public.view
-    def get_resolution(self) -> str:
-        return self.resolution
+    def get_has_coin(self) -> bool:
+        return self.has_coin
 ```
 
 Full SDK available: [genlayer-js](/api-references/genlayer-js) (TypeScript), [genlayer-py](/api-references/genlayer-py) (Python), [CLI](/api-references/genlayer-cli).

--- a/pages/understand-genlayer-protocol/what-makes-genlayer-different.mdx
+++ b/pages/understand-genlayer-protocol/what-makes-genlayer-different.mdx
@@ -1,10 +1,5 @@
-## What Makes GenLayer Different?
-1. **AI-Powered**: Intelligent Contracts interpret and execute human-readable commands, unlocking data-driven decision-making in real time.
+import { Callout } from "nextra-theme-docs";
 
-2. **Web Data Access**: GenLayer’s contracts natively fetch live data, surpassing traditional blockchains that rely on external oracles.
+# What Makes GenLayer Different?
 
-3. **Secure and Reliable**: The Optimistic Democracy consensus algorithm expertly validates non-deterministic outputs, ensuring both efficiency and robust security.
-
-4. **Interoperability**: Designed for seamless interaction with other blockchains and conventional web services, GenLayer bridges multiple ecosystems.
-
-5. **Python-Based SDK**: A Python-centric toolset lowers the barrier to entry, empowering a wide range of developers, data scientists, and AI specialists.
+This page has moved to [What is GenLayer](/understand-genlayer-protocol/what-is-genlayer).

--- a/pages/understand-genlayer-protocol/who-is-genlayer-for.mdx
+++ b/pages/understand-genlayer-protocol/who-is-genlayer-for.mdx
@@ -1,11 +1,5 @@
+import { Callout } from "nextra-theme-docs";
+
 # Who Is GenLayer For?
 
-- **Existing dApps**: Transition away from costly human-based oracles to AI-powered Intelligent Contracts, slashing operational overhead and decision latency.
-
-- **Builders**: Construct the impossible—dApps that benefit from AI-based reasoning, real-time web access, and automated decision-making.
-
-- **Enterprises**: Streamline complex business logic and workflows with AI-driven automation that executes and enforces contractual agreements on-chain.
-
-- **Researchers**: Experiment with next-generation decentralized governance and explore how AI can improve consensus, dispute resolution, and more.
-
-- **Everyone**: Participate in the groundbreaking fusion of AI and blockchain, shaping the future of Web3 technology.
+This page has moved to [What is GenLayer](/understand-genlayer-protocol/what-is-genlayer).

--- a/pages/understand-genlayer-protocol/why-we-are-building-genlayer.mdx
+++ b/pages/understand-genlayer-protocol/why-we-are-building-genlayer.mdx
@@ -1,10 +1,5 @@
+import { Callout } from "nextra-theme-docs";
+
 # Why We Are Building GenLayer
-Traditional smart contracts face critical limitations: they can’t natively interact with the outside world without oracles, and their instructions are constrained to code-based logic. By integrating AI at the protocol level, GenLayer’s Intelligent Contracts can:
 
-1. **Process Natural Language**: Interpret and act upon human-readable text prompts.
-
-2. **Access Real-Time Web Data**: Seamlessly fetch and utilize external data.
-
-This synergy opens a world of new applications that merge on-chain trust with off-chain intelligence. Our vision is a dynamic protocol where intelligent entities—ranging from AI models to automated tools—can autonomously transact and reach real-world alignment.
-
-GenLayer's Optimistic Democracy consensus underpins secure, efficient validation even when outputs are inherently non-deterministic. This makes the platform exceptionally adaptable and robust—primed for modern, AI-driven use cases.
+This page has moved to [What is GenLayer](/understand-genlayer-protocol/what-is-genlayer).


### PR DESCRIPTION
Split single Testnet row into Testnet Asimov and Testnet Bradbury. Added link to Networks page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "What is GenLayer" guide and new Image Processing + Features docs for Intelligent Contracts
  * Restructured homepage messaging and Get Started layout
  * Consolidated and reorganized several protocol pages into a revised navigation with redirects
  * Expanded Use Cases and reframed Challenges → Trade-offs in introductions
  * Updated Intelligent Contract feature cards and environment/faucet details (Testnet Asimov/Bradbury)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->