### PR TITLE
fix: update GenLayer Chain RPC URL and add chain explorer

### DIFF
--- a/pages/developers/networks.mdx
+++ b/pages/developers/networks.mdx
@@ -18,10 +18,11 @@ Production-like testnet with real AI/LLM workloads.
 | | |
 |---|---|
 | **GenLayer RPC** | `https://rpc-bradbury.genlayer.com` |
-| **GenLayer Chain RPC** | `https://zksync-os-testnet-genlayer.zksync.dev` |
+| **GenLayer Chain RPC** | `https://rpc.testnet-chain.genlayer.com` |
 | **Chain ID** | 4221 |
 | **Currency** | GEN |
 | **Explorer** | [explorer-bradbury.genlayer.com](https://explorer-bradbury.genlayer.com) |
+| **Chain Explorer** | [explorer.testnet-chain.genlayer.com](https://explorer.testnet-chain.genlayer.com/) |
 | **Faucet** | [testnet-faucet.genlayer.foundation](https://testnet-faucet.genlayer.foundation) |
 
 <AddToWallet chain={{chainId: "0x107d", chainName: "GenLayer Bradbury", rpcUrls: ["https://rpc-bradbury.genlayer.com"], nativeCurrency: {name: "GEN Token", symbol: "GEN", decimals: 18}, blockExplorerUrls: ["https://explorer-bradbury.genlayer.com"]}} />
@@ -35,10 +36,11 @@ Infrastructure and stress testing.
 | | |
 |---|---|
 | **GenLayer RPC** | `https://rpc-asimov.genlayer.com` |
-| **GenLayer Chain RPC** | `https://zksync-os-testnet-genlayer.zksync.dev` |
+| **GenLayer Chain RPC** | `https://rpc.testnet-chain.genlayer.com` |
 | **Chain ID** | 4221 |
 | **Currency** | GEN |
 | **Explorer** | [explorer-asimov.genlayer.com](https://explorer-asimov.genlayer.com) |
+| **Chain Explorer** | [explorer.testnet-chain.genlayer.com](https://explorer.testnet-chain.genlayer.com/) |
 | **Faucet** | [testnet-faucet.genlayer.foundation](https://testnet-faucet.genlayer.foundation) |
 
 <AddToWallet chain={{chainId: "0x107d", chainName: "GenLayer Asimov", rpcUrls: ["https://rpc-asimov.genlayer.com"], nativeCurrency: {name: "GEN Token", symbol: "GEN", decimals: 18}, blockExplorerUrls: ["https://explorer-asimov.genlayer.com"]}} />
@@ -81,11 +83,12 @@ The underlying zkSync Elastic Chain that GenLayer runs on. You typically don't n
 
 | | |
 |---|---|
-| **RPC** | `https://zksync-os-testnet-genlayer.zksync.dev` |
+| **RPC** | `https://rpc.testnet-chain.genlayer.com` |
 | **Chain ID** | 4221 |
 | **Currency** | GEN |
+| **Explorer** | [explorer.testnet-chain.genlayer.com](https://explorer.testnet-chain.genlayer.com/) |
 
-<AddToWallet chain={{chainId: "0x107d", chainName: "GenLayer Chain Testnet", rpcUrls: ["https://zksync-os-testnet-genlayer.zksync.dev"], nativeCurrency: {name: "GEN Token", symbol: "GEN", decimals: 18}}} />
+<AddToWallet chain={{chainId: "0x107d", chainName: "GenLayer Chain Testnet", rpcUrls: ["https://rpc.testnet-chain.genlayer.com"], nativeCurrency: {name: "GEN Token", symbol: "GEN", decimals: 18}, blockExplorerUrls: ["https://explorer.testnet-chain.genlayer.com"]}} />
 
 ---
 


### PR DESCRIPTION
- Chain RPC: zksync-os-testnet-genlayer.zksync.dev → rpc.testnet-chain.genlayer.com
- Add chain explorer (explorer.testnet-chain.genlayer.com) to GenLayer Chain section and both testnet tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated network RPC endpoints for Testnet Bradbury and Testnet Asimov to reflect current infrastructure
  * Added chain explorer links for both testnet networks to enable transaction and address lookups
  * Enhanced wallet connection with new RPC endpoints and block explorer URLs for improved network integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->