### PR TITLE
ci: use GitHub App token for node sync workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,7 +69,7 @@ Add this to a workflow in the genlayer-node repository:
 
 #### GitHub App (User-Managed)
 
-Access to the private `genlayerlabs/genlayer-node` repository is provided by a GitHub App installed on that repository. The workflow mints a short-lived installation token via `actions/create-github-app-token@v1`.
+Access to the private `genlayerlabs/genlayer-node` repository is provided by a GitHub App installed on that repository. The workflow mints a short-lived installation token via `actions/create-github-app-token@v3`.
 
 Required repository secrets:
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -67,12 +67,19 @@ Add this to a workflow in the genlayer-node repository:
   - Creating pull requests via GitHub CLI (automatically detected by `gh`)
   - General workflow authentication
 
+#### GitHub App (User-Managed)
+
+Access to the private `genlayerlabs/genlayer-node` repository is provided by a GitHub App installed on that repository. The workflow mints a short-lived installation token via `actions/create-github-app-token@v1`.
+
+Required repository secrets:
+
+- `NODE_SYNC_APP_CLIENT_ID`: Client ID of the GitHub App
+- `NODE_SYNC_APP_KEY`: PEM-encoded private key of the GitHub App
+
+The App must be installed on `genlayerlabs/genlayer-node` with at least `Contents: Read` permission. Tokens are scoped to that single repository at mint time.
+
 #### Personal Access Tokens (User-Managed)
 
-- `NODE_REPO_TOKEN` (optional): Personal Access Token for accessing private genlayer-node repository. Used for:
-  - Cloning private genlayer-node repository
-  - Falls back to `GITHUB_TOKEN` if not provided
-  
 - `DOCS_REPO_TOKEN` (in genlayer-node): Token with `repo` scope for triggering this workflow. Used for:
   - Triggering repository dispatch events from genlayer-node
   - Must have `repo` scope to trigger workflows

--- a/.github/workflows/sync-docs-from-node.yml
+++ b/.github/workflows/sync-docs-from-node.yml
@@ -67,9 +67,9 @@ jobs:
       - name: Generate GitHub App token
         id: app-token
         if: steps.extract.outputs.version == 'latest'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.NODE_SYNC_APP_CLIENT_ID }}
+          client-id: ${{ secrets.NODE_SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.NODE_SYNC_APP_KEY }}
           owner: genlayerlabs
           repositories: genlayer-node
@@ -118,9 +118,9 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.NODE_SYNC_APP_CLIENT_ID }}
+          client-id: ${{ secrets.NODE_SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.NODE_SYNC_APP_KEY }}
           owner: genlayerlabs
           repositories: genlayer-node

--- a/.github/workflows/sync-docs-from-node.yml
+++ b/.github/workflows/sync-docs-from-node.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        
+
       - name: Extract version parameter
         id: extract
         run: |
@@ -64,11 +64,21 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Requested version: $VERSION"
 
+      - name: Generate GitHub App token
+        id: app-token
+        if: steps.extract.outputs.version == 'latest'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NODE_SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NODE_SYNC_APP_KEY }}
+          owner: genlayerlabs
+          repositories: genlayer-node
+
       - name: Detect latest version
         id: detect
         if: steps.extract.outputs.version == 'latest'
         env:
-          GITHUB_TOKEN: ${{ secrets.NODE_REPO_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           source .github/scripts/version-utils.sh
           LATEST_TAG=$(detect_latest_version "$GITHUB_TOKEN")
@@ -106,11 +116,20 @@ jobs:
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NODE_SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.NODE_SYNC_APP_KEY }}
+          owner: genlayerlabs
+          repositories: genlayer-node
+
       - name: Clone source repository
         uses: actions/checkout@v4
         with:
           repository: genlayerlabs/genlayer-node
-          token: ${{ secrets.NODE_REPO_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
           sparse-checkout: |
             docs


### PR DESCRIPTION
## Description

Replaces the `NODE_REPO_TOKEN` PAT with a GitHub App installation token for accessing the private `genlayerlabs/genlayer-node` repository in the docs sync workflow.

### Changes

- `.github/workflows/sync-docs-from-node.yml`
  - `prepare` job: added `actions/create-github-app-token@v1` step (gated on `version == 'latest'`) and switched the `Detect latest version` step to use the App token.
  - `sync-files` job: added the same token-mint step before `Clone source repository` and switched the checkout to use the App token.
  - Both token steps are scoped to `owner: genlayerlabs` / `repositories: genlayer-node`.
  - Removed `secrets.NODE_REPO_TOKEN || secrets.GITHUB_TOKEN` fallbacks.
- `.github/workflows/README.md`: replaced the `NODE_REPO_TOKEN` PAT section with a GitHub App section documenting `NODE_SYNC_APP_CLIENT_ID` and `NODE_SYNC_APP_KEY`, plus the required App permission (`Contents: Read`) and installation target.

### Required Repo Secrets

- `NODE_SYNC_APP_CLIENT_ID` — Client ID of the GitHub App
- `NODE_SYNC_APP_KEY` — PEM-encoded private key of the GitHub App

The App must be installed on `genlayerlabs/genlayer-node` with `Contents: Read`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD authentication mechanism to enhance security and reliability in the deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->