### PR TITLE
ci: read app client-id from vars and drop redundant owner

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -71,10 +71,10 @@ Add this to a workflow in the genlayer-node repository:
 
 Access to the private `genlayerlabs/genlayer-node` repository is provided by a GitHub App installed on that repository. The workflow mints a short-lived installation token via `actions/create-github-app-token@v3`.
 
-Required repository secrets:
+Required configuration:
 
-- `NODE_SYNC_APP_CLIENT_ID`: Client ID of the GitHub App
-- `NODE_SYNC_APP_KEY`: PEM-encoded private key of the GitHub App
+- `NODE_SYNC_APP_CLIENT_ID` (repository variable): Client ID of the GitHub App
+- `NODE_SYNC_APP_KEY` (repository secret): PEM-encoded private key of the GitHub App
 
 The App must be installed on `genlayerlabs/genlayer-node` with at least `Contents: Read` permission. Tokens are scoped to that single repository at mint time.
 

--- a/.github/workflows/sync-docs-from-node.yml
+++ b/.github/workflows/sync-docs-from-node.yml
@@ -69,9 +69,8 @@ jobs:
         if: steps.extract.outputs.version == 'latest'
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ secrets.NODE_SYNC_APP_CLIENT_ID }}
+          client-id: ${{ vars.NODE_SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.NODE_SYNC_APP_KEY }}
-          owner: genlayerlabs
           repositories: genlayer-node
 
       - name: Detect latest version
@@ -120,9 +119,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ secrets.NODE_SYNC_APP_CLIENT_ID }}
+          client-id: ${{ vars.NODE_SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.NODE_SYNC_APP_KEY }}
-          owner: genlayerlabs
           repositories: genlayer-node
 
       - name: Clone source repository


### PR DESCRIPTION
## Description

Follow-up to #395. Aligns the GitHub App token-mint steps in `sync-docs-from-node.yml` with the working pattern used in the genlayer-node release workflow.

### Changes

- `.github/workflows/sync-docs-from-node.yml` (both occurrences):
  - `client-id` source: `${{ secrets.NODE_SYNC_APP_CLIENT_ID }}` → `${{ vars.NODE_SYNC_APP_CLIENT_ID }}` (Client IDs are not sensitive and belong in repository variables).
  - Removed `owner: genlayerlabs` — `actions/create-github-app-token` defaults to the current repo's owner, so it's redundant when both repos share the same org.
- `.github/workflows/README.md`: documents `NODE_SYNC_APP_CLIENT_ID` as a repository variable (not a secret), while `NODE_SYNC_APP_KEY` remains a secret.

### Required Configuration

- `NODE_SYNC_APP_CLIENT_ID` — repository **variable**
- `NODE_SYNC_APP_KEY` — repository **secret**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to source application credentials more securely, separating client IDs into repository variables while maintaining secret handling for sensitive authentication keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->