### PR TITLE
ci: scope sync jobs to Node Sync environment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -71,10 +71,12 @@ Add this to a workflow in the genlayer-node repository:
 
 Access to the private `genlayerlabs/genlayer-node` repository is provided by a GitHub App installed on that repository. The workflow mints a short-lived installation token via `actions/create-github-app-token@v3`.
 
-Required configuration:
+Credentials live in the **`Node Sync`** GitHub Environment (Settings → Environments → Node Sync). Any job that needs the App token must declare `environment: Node Sync` at the job level — without it, `secrets.NODE_SYNC_APP_*` resolves to empty.
 
-- `NODE_SYNC_APP_CLIENT_ID` (repository variable): Client ID of the GitHub App
-- `NODE_SYNC_APP_KEY` (repository secret): PEM-encoded private key of the GitHub App
+Required environment secrets:
+
+- `NODE_SYNC_APP_CLIENT_ID`: Client ID of the GitHub App
+- `NODE_SYNC_APP_KEY`: PEM-encoded private key of the GitHub App
 
 The App must be installed on `genlayerlabs/genlayer-node` with at least `Contents: Read` permission. Tokens are scoped to that single repository at mint time.
 

--- a/.github/workflows/sync-docs-from-node.yml
+++ b/.github/workflows/sync-docs-from-node.yml
@@ -47,6 +47,7 @@ jobs:
   prepare:
     name: 'Determine Version'
     runs-on: ubuntu-latest
+    environment: Node Sync
     outputs:
       version: ${{ steps.final_version.outputs.version }}
     steps:
@@ -69,7 +70,7 @@ jobs:
         if: steps.extract.outputs.version == 'latest'
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.NODE_SYNC_APP_CLIENT_ID }}
+          client-id: ${{ secrets.NODE_SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.NODE_SYNC_APP_KEY }}
           repositories: genlayer-node
 
@@ -99,6 +100,7 @@ jobs:
     name: 'Sync Files'
     runs-on: ubuntu-latest
     needs: prepare
+    environment: Node Sync
     strategy:
       matrix:
         sync_type: [changelog, config, config_asimov, config_bradbury, docker_compose, docker_compose_monitoring, alloy_config, greybox_setup, api_gen, api_debug, api_ops]
@@ -119,7 +121,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.NODE_SYNC_APP_CLIENT_ID }}
+          client-id: ${{ secrets.NODE_SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.NODE_SYNC_APP_KEY }}
           repositories: genlayer-node
 


### PR DESCRIPTION
## Description

Fixes the `Sync Documentation from Node Repository` workflow run failures caused by missing credentials at runtime. The App secrets (`NODE_SYNC_APP_CLIENT_ID`, `NODE_SYNC_APP_KEY`) are stored in the **`Node Sync`** GitHub Environment, so jobs that read them must declare `environment: Node Sync` at the job level — otherwise `secrets.NODE_SYNC_APP_*` resolves to empty and the App token mint step receives blank credentials.

### Changes

- `.github/workflows/sync-docs-from-node.yml`:
  - Added `environment: Node Sync` to the `prepare` and `sync-files` jobs (the two jobs that mint the App token).
  - Reverted `client-id` source from `${{ vars.NODE_SYNC_APP_CLIENT_ID }}` to `${{ secrets.NODE_SYNC_APP_CLIENT_ID }}` (both occurrences) — the value is stored as an environment secret in this repo, not a variable.
- `.github/workflows/README.md`: documents the `Node Sync` environment requirement and lists both credentials as environment secrets.

### Required Configuration

GitHub Environment: `Node Sync`
- `NODE_SYNC_APP_CLIENT_ID` (environment secret)
- `NODE_SYNC_APP_KEY` (environment secret)

Failed run that prompted this fix: https://github.com/genlayerlabs/genlayer-docs/actions/runs/25096528000