### PR TITLE
ci: gate node sync on a single approval

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -71,7 +71,7 @@ Add this to a workflow in the genlayer-node repository:
 
 Access to the private `genlayerlabs/genlayer-node` repository is provided by a GitHub App installed on that repository. The workflow mints a short-lived installation token via `actions/create-github-app-token@v3`.
 
-Credentials live in the **`Node Sync`** GitHub Environment (Settings → Environments → Node Sync). Any job that needs the App token must declare `environment: Node Sync` at the job level — without it, `secrets.NODE_SYNC_APP_*` resolves to empty.
+Credentials live in the **`Node Sync`** GitHub Environment (Settings → Environments → Node Sync), which has a Required-reviewers protection rule. To keep the gate to a **single approval per workflow run**, only the `prepare` job declares `environment: Node Sync`; it mints the App token once and exposes it as a job output (`needs.prepare.outputs.token`) for downstream jobs to consume. Adding a second job that declares the same environment would trigger a second approval — avoid that.
 
 Required environment secrets:
 

--- a/.github/workflows/sync-docs-from-node.yml
+++ b/.github/workflows/sync-docs-from-node.yml
@@ -50,6 +50,7 @@ jobs:
     environment: Node Sync
     outputs:
       version: ${{ steps.final_version.outputs.version }}
+      token: ${{ steps.app-token.outputs.token }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -67,7 +68,6 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        if: steps.extract.outputs.version == 'latest'
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ secrets.NODE_SYNC_APP_CLIENT_ID }}
@@ -100,7 +100,6 @@ jobs:
     name: 'Sync Files'
     runs-on: ubuntu-latest
     needs: prepare
-    environment: Node Sync
     strategy:
       matrix:
         sync_type: [changelog, config, config_asimov, config_bradbury, docker_compose, docker_compose_monitoring, alloy_config, greybox_setup, api_gen, api_debug, api_ops]
@@ -117,19 +116,11 @@ jobs:
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.NODE_SYNC_APP_CLIENT_ID }}
-          private-key: ${{ secrets.NODE_SYNC_APP_KEY }}
-          repositories: genlayer-node
-
       - name: Clone source repository
         uses: actions/checkout@v4
         with:
           repository: genlayerlabs/genlayer-node
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ needs.prepare.outputs.token }}
           fetch-depth: 1
           sparse-checkout: |
             docs


### PR DESCRIPTION
## Description

Reduces the docs-sync workflow from two approval prompts per run to one.

The `Node Sync` GitHub Environment carries a Required-reviewers protection rule, and that rule fires once per job that declares the environment. Previously both `prepare` and `sync-files` declared it, so the team had to approve twice for every sync.

### Changes

- `.github/workflows/sync-docs-from-node.yml`:
  - `prepare` job now mints the App token unconditionally (removed the `if: version == 'latest'` gate, since downstream jobs need it regardless) and exposes it as `outputs.token`.
  - `sync-files` job drops `environment: Node Sync` and its own duplicate token-mint step. The `Clone source repository` step now reads the token from `needs.prepare.outputs.token`.
- `.github/workflows/README.md`: documents the single-approval pattern and warns against re-introducing the environment on additional jobs.

### Security note

`actions/create-github-app-token` calls `core.setSecret()` on the token, which masks it in the originating job's logs. GitHub Actions' masking does not propagate across job boundaries, so this pattern relies on no downstream step ever printing `needs.prepare.outputs.token`. The only consumer is `actions/checkout`'s `token:` input, which doesn't log it. Token TTL is ~1 hour, well above the workflow's typical runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub Actions workflow documentation to clarify token management and environment approval processes.

* **Refactor**
  * Optimized CI/CD workflow token generation to streamline pipeline operations and improve efficiency while maintaining security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->