### PR TITLE
ci: sanitize provider in synced node config.yaml

### DIFF
--- a/.github/scripts/sanitize-config.sh
+++ b/.github/scripts/sanitize-config.sh
@@ -25,6 +25,7 @@ echo "Sanitizing config file: $CONFIG_FILE"
 yq -i '
   .rollup.genlayerchainrpcurl = "TODO: Set your GenLayer Chain ZKSync HTTP RPC URL here" |
   .rollup.genlayerchainwebsocketurl = "TODO: Set your GenLayer Chain ZKSync WebSocket RPC URL here" |
+  .rollup.provider = "TODO: Set your GenLayer Chain ZKSync provider" |
   del(.node.dev)
 ' "$CONFIG_FILE"
 


### PR DESCRIPTION
## Description

The upstream `configs/node/config.yaml.example` in `genlayer-node` now exposes a `rollup.provider` field identifying the rollup operator (e.g. `matterlabs`). When the sync workflow imports this file into `content/validators/config.yaml`, that deployment-specific value would otherwise leak into the public docs.

This change extends `.github/scripts/sanitize-config.sh` to replace `.rollup.provider` with `"TODO: Set your GenLayer Chain ZKSync provider"`, alongside the existing placeholders for `genlayerchainrpcurl` and `genlayerchainwebsocketurl`. The replacement runs only against the sanitized copy of `config.yaml`; `asimov.yaml` and `bradbury.yaml` have no `rollup` block and are unaffected.

The new placeholder will appear in `content/validators/config.yaml` on the next node-sync run.