### PR TITLE
docs: add Transaction Context page (gl.message, datetime, tx params)

### DIFF
--- a/pages/developers/intelligent-contracts/features/_meta.json
+++ b/pages/developers/intelligent-contracts/features/_meta.json
@@ -3,6 +3,7 @@
     "error-handling": "Error Handling",
     "upgradability": "Upgradability",
     "value-transfers": "Value Transfers",
+    "transaction-context": "Transaction Context",
     "messages": "Messages",
     "interacting-with-intelligent-contracts": "Interacting with Intelligent Contracts",
     "interacting-with-evm-contracts": "Interacting with EVM Contracts",

--- a/pages/developers/intelligent-contracts/features/messages.mdx
+++ b/pages/developers/intelligent-contracts/features/messages.mdx
@@ -116,17 +116,9 @@ Every Intelligent Contract has a corresponding **ghost contract** on GenLayer Ch
   **Studio:** Ghost contracts are not implemented. The IC address is used directly, and balance is stored in a database table.
 </Callout>
 
-## Message Context (gl.message)
+## Message Context
 
-Every contract execution has access to `gl.message`:
-
-| Field | Type | Description |
-|---|---|---|
-| `sender_address` | `Address` | Immediate caller — EOA, EVM contract, or IC depending on how the call was initiated |
-| `origin_address` | `Address` | Original transaction submitter — preserved through internal message chains |
-| `contract_address` | `Address` | The current contract's own address |
-| `value` | `u256` | GEN sent with the call (only in `@gl.public.write.payable` methods) |
-| `chain_id` | `u256` | Current chain ID |
+Caller and execution metadata (`sender_address`, `origin_address`, `contract_address`, `value`, `chain_id`, transaction datetime, etc.) is available via `gl.message` and `gl.message_raw`. See [Transaction Context](/developers/intelligent-contracts/features/transaction-context).
 
 ## Timing: Accepted vs Finalized
 

--- a/pages/developers/intelligent-contracts/features/transaction-context.mdx
+++ b/pages/developers/intelligent-contracts/features/transaction-context.mdx
@@ -1,0 +1,106 @@
+import { Callout } from "nextra-theme-docs";
+
+# Transaction Context
+
+Every contract execution has access to information about the transaction that triggered it — caller addresses, value, chain ID, and the transaction's datetime. This page covers what is available, how to access it, and what is *not* available.
+
+## `gl.message` — typed accessors
+
+The most common fields are exposed as a typed `NamedTuple`:
+
+| Field | Type | Description |
+|---|---|---|
+| `sender_address` | `Address` | Immediate caller — EOA, EVM contract, or IC depending on how the call was initiated |
+| `origin_address` | `Address` | Original transaction submitter — preserved through internal message chains |
+| `contract_address` | `Address` | The current contract's own address |
+| `value` | `u256` | GEN sent with the call (only in `@gl.public.write.payable` methods) |
+| `chain_id` | `u256` | Current chain ID |
+
+```python
+@gl.public.write
+def deposit(self):
+    self.balances[gl.message.sender_address] += gl.message.value
+```
+
+For the difference between `sender_address` and `origin_address` across internal message chains, see [Messages](/developers/intelligent-contracts/features/messages).
+
+## `gl.message_raw` — full message dict
+
+`gl.message_raw` is a `TypedDict` with everything the bootloader receives. It includes all `gl.message` fields plus:
+
+| Field | Type | Description |
+|---|---|---|
+| `datetime` | `str` | Transaction datetime as an ISO 8601 string |
+| `is_init` | `bool` | `True` iff this execution is a deployment |
+| `stack` | `list[Address]` | Stack of view-method callers, excluding the current contract |
+| `entry_kind` | `int` | `0` = MAIN, `1` = SANDBOX, `2` = CONSENSUS_STAGE |
+| `entry_data` | `bytes` | Raw entry payload |
+| `entry_stage_data` | — | Consensus-stage-specific data |
+
+```python
+# Detect whether the current execution is a deploy
+if gl.message_raw['is_init']:
+    self.deployer = gl.message.sender_address
+```
+
+<Callout type="info">
+  Prefer `gl.message` for the common fields — it gives you autocompletion and type checking. Reach for `gl.message_raw` only when you need one of the extra fields.
+</Callout>
+
+## Time in a contract
+
+Time inside the GenVM is **deterministic and pinned to the transaction's datetime**. Every validator re-executing the transaction sees the same value, so you can use it for storage, comparisons, and prompt context without breaking equivalence.
+
+The Python standard library's clock is wired to the transaction datetime — `datetime.now()`, `datetime.now(tz)`, and `time.time()` all return the same value across validators.
+
+### Common patterns
+
+**Unix timestamp for arithmetic:**
+
+```python
+from datetime import datetime, timezone
+
+@gl.public.write
+def mint(self):
+    now = int(datetime.now(timezone.utc).timestamp())
+    self.tokens[gl.message.sender_address] = Token(
+        expiry=u256(now + 86400),  # 24h from now
+    )
+```
+
+**Expiry check:**
+
+```python
+@gl.public.view
+def is_expired(self, token_id: u256) -> bool:
+    now = int(datetime.now(timezone.utc).timestamp())
+    return now > int(self.tokens[token_id].expiry)
+```
+
+**ISO string for audit trails or events:**
+
+```python
+@gl.public.write
+def submit(self, payload: str):
+    self.submissions.append(Submission(
+        sender=gl.message.sender_address,
+        payload=payload,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    ))
+```
+
+**Raw ISO string from the message (skip the clock):**
+
+```python
+ts: str = gl.message_raw['datetime']
+```
+
+<Callout type="warning">
+  The clock returns the **transaction datetime**, not host wall-clock time. Do not call `datetime.now()` expecting current real-world time — by the time validators re-execute, the transaction may be minutes or hours old. Use it for relative arithmetic ("expires 24h after the tx") and timestamping, not for "is it past 5pm right now".
+</Callout>
+
+## What is *not* in the context
+
+- **No block number, no block hash.** The transaction context does not carry block-level metadata. If your contract needs block height, fetch it via [Web Access](/developers/intelligent-contracts/features/web-access) against an RPC inside a non-deterministic block.
+- **No gas price, no nonce.** Transaction metadata beyond what is listed above is not exposed to the contract.
+- **No host wall-clock time.** As above — the clock is the transaction datetime, not the validator's current time.


### PR DESCRIPTION
## Summary

- Adds a dedicated **Transaction Context** page covering `gl.message`, `gl.message_raw`, and — importantly — the fact that `datetime.now()` / `time.time()` are **deterministic** inside the GenVM (the WASI clock is seeded with the transaction datetime).
- Moves the `gl.message` field table out of `messages.mdx` (it was execution context, not message-passing semantics) and replaces it with a one-line link.
- Slots the new page between **Value Transfers** and **Messages** in `_meta.json`.

## Motivation

Searching the docs for `timestamp` turns up nothing useful — only a passing `u32` use-case mention and a non-determinism warning about API timestamps. There was no documentation of:

- How to get the transaction datetime inside a contract.
- That `datetime.now()` is safe and deterministic (the canonical source of non-determinism in normal Python — devs reasonably assume it would break equivalence).
- The extra fields on `gl.message_raw` (`datetime`, `is_init`, `entry_kind`, `stack`).
- What's *not* in the context (block number, gas price, wall-clock).

Confirmed against `genvm/runners/genlayer-py-std/src/genlayer/_internal/msg.py` and `genvm/executor/src/wasi/preview1.rs:379` (clock seeded with `unix_timestamp` from the message). Pattern is already in production use in Rally (`XID.py`, `CampaignShard.py`).

## Test plan

- [ ] `pnpm dev` and verify the new page renders under Developers → Intelligent Contracts → Features → Transaction Context
- [ ] Verify the link from `messages.mdx` resolves
- [ ] Verify nav order: Value Transfers → Transaction Context → Messages