### PR TITLE
docs: align top-level positioning with Agentic Adjudication Layer narrative

### DIFF
--- a/pages/FAQ.mdx
+++ b/pages/FAQ.mdx
@@ -7,13 +7,25 @@ title: "FAQ"
 <details>
   <summary>What is GenLayer?</summary>
 
-  GenLayer is a blockchain where validator nodes powered by diverse AI models reach consensus on subjective decisions. It's built as an L2 on zkSync Elastic Chain, anchoring to Ethereum's security. Contracts on GenLayer — called **Intelligent Contracts** — can interpret language, process images, fetch live web data, and make subjective decisions. See [What is GenLayer](/understand-genlayer-protocol/what-is-genlayer).
+  GenLayer is the **adjudication layer for the agentic economy**. It uses decentralized AI-validator consensus to resolve contracts that require judgment, not just code. It's built as an L2 on zkSync Elastic Chain, anchoring to Ethereum's security. Contracts on GenLayer — called **Intelligent Contracts** — can interpret language, process images, fetch live web data, and reach consensus on contested or subjective outcomes. See [What is GenLayer](/understand-genlayer-protocol/what-is-genlayer).
 </details>
 
 <details>
   <summary>How is GenLayer different from other blockchains?</summary>
 
-  Traditional smart contracts can only execute deterministic logic and rely on external oracles for off-chain data. GenLayer integrates AI at the protocol level — contracts natively access LLMs, the web, and image processing. No oracles, no intermediaries. See [What is GenLayer](/understand-genlayer-protocol/what-is-genlayer#how-it-compares).
+  Traditional smart contracts can only execute deterministic logic and rely on external oracles for off-chain data. GenLayer integrates AI at the protocol level — contracts natively access LLMs, the web, and image processing. No oracles, no intermediaries. Where Bitcoin reached consensus on the *order* of transactions and Ethereum on the *execution* of code, GenLayer reaches consensus on the **meaning** of transactions. See [What is GenLayer](/understand-genlayer-protocol/what-is-genlayer#how-it-compares).
+</details>
+
+<details>
+  <summary>Is GenLayer trying to replace courts?</summary>
+
+  No. GenLayer is built to provide a **first-instance, internet-native adjudication layer** for disputes that arrive too quickly, too often, and too globally for traditional courts to handle in time — particularly the disputes the agentic economy is starting to produce at machine speed. It is designed to complement, not replace, existing legal frameworks.
+</details>
+
+<details>
+  <summary>Where does GenLayer fit in the agentic-commerce stack?</summary>
+
+  The agentic-commerce stack — Coinbase's [x402](https://www.x402.org/) for payments, Ethereum's [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) for trustless agent identity, the Linux Foundation's [A2A](https://a2a-protocol.org) for agent interoperability, plus Stripe/OpenAI's ACP, Visa's Trusted Agent Protocol, Google's AP2, and Mastercard's Agent Pay — engineers the happy path. None of these standards ships dispute resolution. GenLayer is the layer they reach for when a commitment becomes contested.
 </details>
 
 <details>
@@ -67,7 +79,7 @@ title: "FAQ"
 <details>
   <summary>What can I build?</summary>
 
-  Anything requiring subjective judgment: dispute resolution, prediction markets, insurance claims, content verification, compliance automation, AI-governed DAOs, and more. See [Use Cases](/understand-genlayer-protocol/typical-use-cases) and [projects building on GenLayer](https://portal.genlayer.foundation/#/).
+  Anything requiring judgment that deterministic code alone can't resolve: performance and milestone adjudication (bounties, grants, retro funding), adjudication inside the agentic-commerce stack (agent SLAs, escrow on ambiguous completion, reputation disputes), prediction markets, insurance claims, content verification, compliance automation, AI-governed DAOs, and more. See [Use Cases](/understand-genlayer-protocol/typical-use-cases) and [projects building on GenLayer](https://portal.genlayer.foundation/#/).
 </details>
 
 <details>

--- a/pages/glossary.cmdx
+++ b/pages/glossary.cmdx
@@ -1,8 +1,21 @@
 # Glossary
 
-- **Validators:** Participants who stake tokens to earn the right to validate transactions. They are critical in both the initial validation and the subsequent appeals process, if necessary.
-  
+- **Adjudication:** The act of weighing evidence, interpreting intent, and reaching a verdict the parties accept as legitimate. GenLayer is built as a first-instance, internet-native adjudication layer — fast, neutral, and reachable by anyone — for the disputes the agentic economy will produce at machine speed.
+
+- **Agentic economy:** The economy in which software agents transact, negotiate, and coordinate on their own behalf at machine speed, surfacing commitments and disagreements faster and more often than human-built institutions were designed to handle.
+
+- **Intelligent Contract:** A GenLayer smart contract written in Python that can read the web, interpret natural language, and reach consensus on subjective outcomes. The unit GenLayer adjudicates.
+
+- **Equivalence Principle:** The technical primitive at the core of GenLayer. The formal expression of the idea that two answers can be different in form yet equivalent in meaning, so a network of independent AI validators can reach consensus on non-deterministic outcomes.
+
+- **Optimistic Democracy:** GenLayer's consensus mechanism. A leader validator proposes a result; the rest of a randomly selected validator set independently evaluates it; majority agreement accepts the transaction, and anyone can appeal to expand the validator set.
+
+- **Validators:** Participants who stake tokens to earn the right to validate transactions. Critical in both the initial validation and the subsequent appeals process.
+
 - **Leader Selection:** A process that randomly selects one validator to propose the execution outcome for each transaction, ensuring fairness and reducing potential biases.
 
-- **Appeals Process:** This component allows any network participant to contest the results of a transaction's validation during a designated Finality Window, promoting transparency and accountability.
+- **Appeals Process:** Allows any network participant to contest the result of a transaction's validation during a designated Finality Window, promoting transparency and accountability.
 
+- **GenVM:** GenLayer's sandboxed execution environment for Intelligent Contracts — a WebAssembly-based VM running a Python interpreter with native access to LLMs, web data, and non-deterministic operations.
+
+- **Ghost contract:** The EVM-layer counterpart of every Intelligent Contract, deployed at the same address. Holds the contract's GEN balance, relays transactions to consensus, and executes external messages back into the chain layer.

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -2,17 +2,19 @@ import Image from 'next/image'
 import { Card, Cards } from 'nextra-theme-docs'
 import CustomCard from '../components/card'
 
-## Trust Infrastructure for the AI Age
+## The Adjudication Layer for the Agentic Economy
 
-GenLayer is a blockchain where validator nodes powered by diverse AI models reach consensus on subjective decisions — a synthetic jurisdiction on-chain.
+GenLayer uses decentralized AI-validator consensus to resolve contracts that require judgment, not just code.
 
 Intelligent Contracts interpret language, process unstructured data, and pull live web inputs. No oracles, no intermediaries.
 
 - **Bitcoin** — Trustless Money
 - **Ethereum** — Trustless Computation
-- **GenLayer** — Trustless Decision-Making
+- **GenLayer** — Trustless Adjudication
 
-Explore [typical use cases](/understand-genlayer-protocol/typical-use-cases) or jump straight into building.
+The agentic-commerce stack is being built in public — Coinbase's [x402](https://www.x402.org/) for payments, Ethereum's [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) for trustless agent identity, the Linux Foundation's [A2A](https://a2a-protocol.org) for agent interoperability, plus Stripe/OpenAI's ACP, Visa's Trusted Agent Protocol, Google's AP2, and Mastercard's Agent Pay. Every layer engineers the happy path. None ships dispute resolution. GenLayer fills that gap.
+
+Explore [use cases](/understand-genlayer-protocol/typical-use-cases) or jump straight into building.
 
 ## Get Started
 

--- a/pages/understand-genlayer-protocol/optimistic-democracy-how-genlayer-works.mdx
+++ b/pages/understand-genlayer-protocol/optimistic-democracy-how-genlayer-works.mdx
@@ -4,7 +4,7 @@ import { Callout } from "nextra-theme-docs";
 
 ## Optimistic Democracy
 
-GenLayer uses **Optimistic Democracy** for consensus — a mechanism where validators running diverse AI models independently evaluate transactions and vote on outcomes. It applies [Condorcet's Jury Theorem](https://en.wikipedia.org/wiki/Condorcet%27s_jury_theorem): a group of independent reasoners is more likely to reach the correct answer than any individual.
+GenLayer uses **Optimistic Democracy** for consensus — a mechanism where validators running diverse AI models independently evaluate transactions and vote on outcomes. It applies [Condorcet's Jury Theorem](https://en.wikipedia.org/wiki/Condorcet%27s_jury_theorem): a group of independent reasoners is more likely to reach the correct answer than any individual. This is what lets GenLayer act as an **adjudication layer** for the agentic economy — judgments emerge from a diverse validator set rather than from any one model, operator, or jurisdiction.
 
 Transactions are accepted if a majority of validators agree. Anyone can appeal an accepted result, triggering re-evaluation by a new, larger validator set. This process can escalate through multiple rounds until a final decision is reached.
 

--- a/pages/understand-genlayer-protocol/typical-use-cases.mdx
+++ b/pages/understand-genlayer-protocol/typical-use-cases.mdx
@@ -1,65 +1,61 @@
 # Use Cases
 
-GenLayer enables applications that require subjective judgment — decisions that traditional smart contracts can't make because they need to interpret language, evaluate evidence, or assess quality.
+GenLayer is built for commitments where outcomes depend on judgment — evaluating evidence, interpreting language, or assessing quality — and where a deterministic smart contract alone cannot resolve them.
 
-## Dispute Resolution
+The use cases below are grouped by where the need for adjudication is most acute today.
 
-AI validators evaluate evidence and deliver verdicts in minutes. Applies to:
+## 1. Performance & Milestone Adjudication
 
-- **Agentic commerce** — AI agents transacting autonomously ([ERC-8183](https://eips.ethereum.org/EIPS/eip-8183)) need trustless arbitration for SLA compliance, delivery verification, service quality
+Payments, rewards, or recognition that depend on whether some obligation was actually fulfilled under criteria that are partly measurable and partly interpretive. The money is already on-chain. The commitment is already written down. The dispute already happens — and today it is resolved by human bottlenecks that do not scale.
+
+- **Bounties** where payout depends on whether the work met the spec
+- **Grant milestones** where tranche release turns on contested deliverables
+- **Retroactive funding rounds** where allocation depends on impact assessment
+- **Creator economies** where AI-scored rewards generate disputes with no resolution layer
+- **Prediction markets** with subjective outcomes ([example contract](/developers/intelligent-contracts/examples/prediction))
+- **Contributor performance** tied to vesting or continued compensation
+- **Freelance and gig work** — was the deliverable satisfactory? AI consensus replaces subjective back-and-forth
 - **Chargebacks** — buyer/seller disputes resolved by analyzing shipping records, communication logs, and transaction history
-- **Freelance & gig work** — was the deliverable satisfactory? AI consensus replaces subjective back-and-forth
 
-## Rule & Constitution Verification
+## 2. Adjudication Inside the Agentic-Commerce Stack
 
-Check whether something meets a set of criteria defined in natural language:
+GenLayer plugs into the infrastructure the industry is building right now: payment rails ([x402](https://www.x402.org/)), agent identity and reputation ([ERC-8004](https://eips.ethereum.org/EIPS/eip-8004)), agent-to-agent task exchange ([A2A](https://a2a-protocol.org)), plus Stripe/OpenAI's ACP, Visa's Trusted Agent Protocol, Google's AP2, and Mastercard's Agent Pay. Each standard ships the happy path and carves the moment of disagreement out as someone else's problem. GenLayer is that someone else.
+
+- **Agent-executed job disputes** — was the task delivered to spec?
+- **Escrow release on ambiguous completion** — agent counterparties needing neutral resolution
+- **SLA enforcement on agent work** — quality, latency, or scope claims
+- **Reputation claims contested between counterparties** in ERC-8004-style identity systems
+- **Coverage claims on agent-to-agent commitments** — parametric and evidence-based
+- **Multi-agent workflows** where responsibility for failure has to be assigned across participants
+
+## 3. Rule & Constitution Verification
+
+Check whether something meets a set of criteria defined in natural language — a foundational primitive that many applications reduce to.
 
 - Does a new prediction market meet listing guidelines?
 - Does a DAO proposal comply with the organization's charter?
 - Does a content submission follow community standards?
 - Does a transaction comply with regulatory requirements?
 
-This is a foundational primitive — many applications are instances of "evaluate X against rules Y."
+## 4. Adjacent Surfaces
 
-## Prediction Markets
+The same primitive shows up across digital commerce:
 
-Markets that resolve automatically by fetching outcomes from primary sources. No centralized oracle or authority needed.
-
-→ [Example contract](/developers/intelligent-contracts/examples/prediction)
-
-## Social Content Verification
-
-AI validators assess content quality, detect plagiarism, and distribute rewards based on originality and engagement. Replaces centralized content moderation with consensus-driven evaluation.
-
-## Code & Work Quality Assurance
-
-Staked submissions where reviewers are economically incentivized to find issues. AI validators assess code quality, deliverable completeness, or compliance with specifications.
-
-## AI-Governed Organizations
-
-DAOs where proposals are written in natural language, evaluated against real-time data, and executed automatically when conditions align.
-
-## Compliance Automation
-
-Real-time screening against sanctions lists, KYC/AML requirements, and changing regulations. Contracts read authoritative sources directly — no manual updates needed.
-
-## Insurance
-
-Parametric and evidence-based insurance where claims are evaluated by AI validators. Contracts fetch weather data, flight statuses, or photographic evidence to assess claims and trigger payouts automatically — no adjusters, no weeks of waiting.
-
-## Argumentation & Debate Markets
-
-Structured debates where participants stake positions and AI consensus determines outcomes — a new primitive for information markets.
+- **Insurance** — parametric and evidence-based claims evaluated by AI validators. Contracts fetch weather data, flight statuses, or photographic evidence to assess claims and trigger payouts automatically — no adjusters, no weeks of waiting.
+- **Social content verification** — AI validators assess quality, detect plagiarism, and distribute rewards based on originality and engagement. Replaces centralized moderation with consensus-driven evaluation.
+- **Code & work quality assurance** — staked submissions where reviewers are economically incentivized to find issues; AI validators assess deliverable completeness or compliance with specifications.
+- **AI-governed organizations** — DAOs where proposals are written in natural language, evaluated against real-time data, and executed automatically when conditions align.
+- **Compliance automation** — real-time screening against sanctions lists, KYC/AML requirements, and changing regulations. Contracts read authoritative sources directly — no manual updates needed.
+- **Argumentation and debate markets** — structured debates where participants stake positions and AI consensus determines outcomes, a new primitive for information markets.
 
 ## What Makes These Possible
 
-All of these share a common pattern: they require **subjective judgment** that traditional smart contracts can't perform.
+All of these share a common pattern: they require **judgment** that traditional smart contracts can't perform. GenLayer's Intelligent Contracts can:
 
-GenLayer's Intelligent Contracts can:
 - Fetch and interpret live web data
 - Process natural language and unstructured inputs
 - Make subjective decisions through multi-validator AI consensus
-- Execute outcomes on-chain with full finality
+- Execute outcomes on-chain with full finality — justice in minutes, not months
 
 See [projects building on GenLayer](https://portal.genlayer.foundation/#/) for live examples.
 

--- a/pages/understand-genlayer-protocol/what-is-genlayer.mdx
+++ b/pages/understand-genlayer-protocol/what-is-genlayer.mdx
@@ -2,15 +2,33 @@ import { Callout } from "nextra-theme-docs";
 
 # What is GenLayer
 
-## Trust Infrastructure for the AI Age
+## The Adjudication Layer for the Agentic Economy
 
-GenLayer is a blockchain where validator nodes powered by diverse AI models reach consensus on subjective decisions — a synthetic jurisdiction on-chain.
+GenLayer uses decentralized AI-validator consensus to resolve contracts that require judgment, not just code.
 
 Intelligent Contracts interpret language, process unstructured data, and pull live web inputs. No oracles, no intermediaries.
 
 - **Bitcoin** — Trustless Money
 - **Ethereum** — Trustless Computation
-- **GenLayer** — Trustless Decision-Making
+- **GenLayer** — Trustless Adjudication
+
+Where Bitcoin reached consensus on the *order* of transactions and Ethereum on the *execution* of code, GenLayer reaches consensus on the **meaning** of transactions. The technical primitive that makes this possible is the [Equivalence Principle](/developers/intelligent-contracts/features/non-determinism): two answers can be different in form yet equivalent in meaning, and a network of independent AI validators can agree on that.
+
+## The Missing Layer
+
+The agentic-commerce stack is being built in the open — and every layer of it stops at the happy path.
+
+| Layer | Standard | What it handles | Dispute resolution |
+|---|---|---|---|
+| Payments | [x402](https://www.x402.org/) (Coinbase) | Internet-native, agent-friendly payments | Not specified |
+| Identity & reputation | [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) (Ethereum) | Trustless agent identity | Delegated to external validation protocols |
+| Agent interoperability | [A2A](https://a2a-protocol.org) (Linux Foundation / Google) | How agents discover each other and exchange tasks | Not defined within the protocol |
+
+Other players are stacking in alongside them — Stripe + OpenAI's ACP (already powering ChatGPT checkout), Visa's Trusted Agent Protocol, Google's AP2, Mastercard's Agent Pay + BVNK, and Tempo (Stripe / Paradigm L1). The shape is the same in every case: the payment goes through, the job is accepted, the reputation is updated — and the moment a single material dispute appears, the stack reaches for a function it does not have.
+
+That function is **adjudication**. Not a sovereign court. A credible, machine-speed mechanism for evaluating contested commitments, weighing evidence, interpreting language, reaching a verdict, and attaching consequences to it.
+
+GenLayer is that layer.
 
 ## What Intelligent Contracts Can Do
 

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -20,7 +20,7 @@ const config: DocsThemeConfig = {
   navigation: true,
   head: (
     <>
-      <meta name="description" content="GenLayer the intelligence layer of the Internet" />
+      <meta name="description" content="GenLayer — the adjudication layer for the agentic economy" />
       <link rel="icon" href="/favicon.png" type="image/png" media="(prefers-color-scheme: light)" />
       <link rel="icon" href="/favicon-dark.png" type="image/png" media="(prefers-color-scheme: dark)" />
     </>
@@ -50,16 +50,16 @@ const config: DocsThemeConfig = {
     const isHomePage = asPath === "/";
     return {
       titleTemplate: isHomePage
-        ? "GenLayer the intelligence layer of the Internet - Documentation"
-        : "%s | Detailed GenLayer Documentation",
+        ? "GenLayer — The Adjudication Layer for the Agentic Economy"
+        : "%s | GenLayer Documentation",
       openGraph: {
         type: "website",
         locale: "en_IE",
         url: "https://docs.genlayer.com/" + asPath,
-        site_name: "GenLayer: the intelligence layer of the Internet - Documentation",
-        title: "GenLayer: the intelligence layer of the Internet - Documentation",
+        site_name: "GenLayer — The Adjudication Layer for the Agentic Economy",
+        title: "GenLayer — The Adjudication Layer for the Agentic Economy",
         description:
-          "Build and deploy AI-powered applications with GenLayer. Comprehensive documentation, guides, and API references for developers.",
+          "Documentation for GenLayer, the adjudication layer for the agentic economy. Build Intelligent Contracts in Python, integrate the SDKs, and run a validator node.",
         images: [
           {
             url: "/assets/genlayer.png",
@@ -76,11 +76,11 @@ const config: DocsThemeConfig = {
       additionalMetaTags: [
         {
           name: "description",
-          content: "Comprehensive documentation and guides on how to use GenLayer.",
+          content: "Documentation for GenLayer, the adjudication layer for the agentic economy. Build Intelligent Contracts in Python, integrate the SDKs, and run a validator node.",
         },
         {
           property: "og:description",
-          content: "GenLayer the intelligence layer of the Internet - Documentation.",
+          content: "GenLayer — the adjudication layer for the agentic economy. Decentralized AI-validator consensus for contracts that need judgment, not just code.",
         },
         {
           property: "og:image",


### PR DESCRIPTION
## Summary

Aligns the docs site with the GenLayer DNA narrative. The old positioning ("intelligence layer of the Internet" / "Trust Infrastructure for the AI Age" / "Trustless Decision-Making") is replaced with the new framing: **The Adjudication Layer for the Agentic Economy**.

Scoped to top-level positioning surfaces — does not touch dev-facing technical content, code examples, or APIs. The deeper narrative material (manifesto, trust-history, strategic pillars, Foundation self-dissolution) is intentionally **left out of the docs** and belongs on the marketing site / blog.

## Changes

- **`theme.config.tsx`** — Site title, SEO description, OG metadata.
- **`pages/index.mdx`** — New tagline. Trinity updated to Money / Computation / Adjudication. Added a paragraph name-checking the agentic-commerce stack (Coinbase x402, ERC-8004, A2A, plus Stripe/OpenAI ACP, Visa TAP, Google AP2, Mastercard Agent Pay) for SEO/AEO.
- **`pages/understand-genlayer-protocol/what-is-genlayer.mdx`** — New headline + opening. New "The Missing Layer" section with a comparison table over the agentic-commerce stack and the gap they all defer. Equivalence Principle name-checked at top level.
- **`pages/understand-genlayer-protocol/typical-use-cases.mdx`** — Rewritten around the two GTM wedges: (1) Performance & milestone adjudication, (2) Adjudication inside the agentic-commerce stack. Adjacent surfaces (insurance, content, compliance, etc.) kept but moved below.
- **`pages/FAQ.mdx`** — Tightened the "What is GenLayer" answer. Added "Is GenLayer trying to replace courts?" and "Where does GenLayer fit in the agentic-commerce stack?".
- **`pages/glossary.cmdx`** — Added Adjudication, Agentic economy, Intelligent Contract, Equivalence Principle, GenVM, Ghost contract entries.
- **`pages/understand-genlayer-protocol/optimistic-democracy-how-genlayer-works.mdx`** — One-line link from Optimistic Democracy to the adjudication framing.

## Choices

- **Tagline tone**: kept marketing-ier lines (e.g. "Justice in minutes, not months.") out of headlines; used the phrase once, in a bullet at the bottom of the use-cases page.
- **No nav or URL changes**, no broken anchor links (verified `#how-it-compares` still resolves).
- **Year framing**: avoided putting concrete years (2030 / 2034) in the docs — the DNA doc itself is inconsistent on this and docs decay fast.

## Test plan

- [ ] `pnpm dev`, check homepage, What is GenLayer, Use Cases, FAQ, Glossary
- [ ] Verify SEO `<title>` and meta description on both home and a sub-page
- [ ] Verify the link from FAQ to `#how-it-compares` still resolves