### PR TITLE
docs: elevate GenLayer Skills as the main developer/validator entry point

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -6,6 +6,12 @@
   "api-references": "API References",
   "partners": "Partners",
   "FAQ": "FAQ",
+  "skills": {
+    "title": "Skills 🤖",
+    "type": "page",
+    "href": "https://skills.genlayer.com/",
+    "newWindow": true
+  },
   "blog": {
     "title": "Blog 📚",
     "type": "page",

--- a/pages/developers.mdx
+++ b/pages/developers.mdx
@@ -1,10 +1,26 @@
 import { Card, Cards } from 'nextra-theme-docs'
+import { Callout } from 'nextra-theme-docs'
 
 # Getting Started with GenLayer
 
-Welcome to the GenLayer getting started guide. This guide helps developers exploit the full potential of the GenLayer environment. This documentation will provide you with the tools and knowledge needed to build, deploy, and manage Intelligent Contracts on GenLayer.
+This guide helps developers build, deploy, and integrate Intelligent Contracts on GenLayer.
 
-The next topics focus on key areas of the development process. From setting up your development environment and writing your first Intelligent Contract to exploring advanced features and best practices, these resources are designed to support your journey in creating cutting-edge decentralized applications on GenLayer. Click on any link to delve into detailed guides and enhance your development skills with GenLayer.
+## Start with Skills (Recommended)
+
+The fastest path from zero to deployed contract is the [GenLayer Skills](https://skills.genlayer.com/) plugin for Claude Code. The `genlayer-dev` skill scaffolds a project, runs the linter and direct-mode tests, deploys to testnet, and walks you through the SDKs interactively.
+
+```bash copy
+claude /plugin marketplace add genlayerlabs/skills
+claude /plugin install genlayer-dev@genlayerlabs
+```
+
+Then run `claude /genlayer-dev` (or just ask Claude what to do next). The skill bundles the same workflows documented on this site — it just runs them for you.
+
+<Callout type="info">
+  Prefer to set things up manually or read the references first? The cards below cover every topic in depth, and the [Tooling Setup](/developers/intelligent-contracts/tooling-setup) page describes the manual install path.
+</Callout>
+
+## Reference
 
 import { Tabs } from 'nextra/components'
  

--- a/pages/developers/intelligent-contracts/tooling-setup.mdx
+++ b/pages/developers/intelligent-contracts/tooling-setup.mdx
@@ -5,6 +5,19 @@ import CustomCard from '../../../components/card'
 
 This guide covers everything you need to develop, test, and deploy Intelligent Contracts — from zero-setup exploration to a full local development environment with linting, testing, and agent-assisted workflows.
 
+## Recommended: GenLayer Skills
+
+The [GenLayer Skills](https://skills.genlayer.com/) plugin for Claude Code is the fastest path to a working development environment. The `genlayer-dev` skill scaffolds a project, installs prerequisites, runs the linter and direct-mode tests, and walks you through deployment — interactively.
+
+```bash copy
+claude /plugin marketplace add genlayerlabs/skills
+claude /plugin install genlayer-dev@genlayerlabs
+```
+
+Then run `claude /genlayer-dev` and follow the prompts. The skill bundles the same workflows documented in the rest of this page — it just runs them for you.
+
+The rest of this guide describes the manual setup, the reference path for anyone who wants fine-grained control or is integrating with existing tooling.
+
 ## Quick Start: GenLayer Studio
 
 The fastest way to start is [studio.genlayer.com](https://studio.genlayer.com) — a web-based IDE where you can write, deploy, and interact with Intelligent Contracts with zero setup.
@@ -309,14 +322,11 @@ The [GenLayer VS Code Extension](https://marketplace.visualstudio.com/items?item
 
 The boilerplate is designed to work well with AI coding agents. The linter and direct mode tests provide a fast feedback loop that agents can use without spinning up infrastructure.
 
-The [GenLayer Skills](https://github.com/genlayerlabs/skills) repository provides a Claude Code plugin marketplace with operational skills for GenLayer development:
+For Claude Code, install the [GenLayer Skills](https://skills.genlayer.com/) marketplace (covered at the top of this page) — it bundles the workflows below behind interactive commands.
 
-```bash
-# Add the skills marketplace to Claude Code
-/plugin marketplace add genlayerlabs/skills
-```
+For other IDEs and clients, the GenLayer MCP servers provide the same capabilities via the Model Context Protocol:
 
-The [GenLayer MCP Server](https://www.npmjs.com/package/genlayer-mcp) provides contract generation and GenLayer-specific guidance directly in your IDE via the Model Context Protocol:
+The [GenLayer MCP Server](https://www.npmjs.com/package/genlayer-mcp) provides contract generation and GenLayer-specific guidance directly in your IDE:
 
 ```bash
 # Add to Claude Code

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 import { Card, Cards } from 'nextra-theme-docs'
+import { Callout } from 'nextra-theme-docs'
 import CustomCard from '../components/card'
 
 ## The Adjudication Layer for the Agentic Economy
@@ -15,6 +16,15 @@ Intelligent Contracts interpret language, process unstructured data, and pull li
 The agentic-commerce stack is being built in public — Coinbase's [x402](https://www.x402.org/) for payments, Ethereum's [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) for trustless agent identity, the Linux Foundation's [A2A](https://a2a-protocol.org) for agent interoperability, plus Stripe/OpenAI's ACP, Visa's Trusted Agent Protocol, Google's AP2, and Mastercard's Agent Pay. Every layer engineers the happy path. None ships dispute resolution. GenLayer fills that gap.
 
 Explore [use cases](/understand-genlayer-protocol/typical-use-cases) or jump straight into building.
+
+<Callout type="info">
+  **Start with Skills 🤖** — The fastest way to build a contract or run a validator is the [GenLayer Skills](https://skills.genlayer.com/) plugin for Claude Code. One command scaffolds, deploys, and operates — no manual setup.
+
+  ```bash
+  claude /plugin marketplace add genlayerlabs/skills
+  # then: genlayer-dev (build contracts) or genlayernode (run a validator)
+  ```
+</Callout>
 
 ## Get Started
 

--- a/pages/validators/setup-guide.mdx
+++ b/pages/validators/setup-guide.mdx
@@ -73,7 +73,7 @@ That's it. The wizard will ask questions and guide you through everything.
   The AI wizard uses the same underlying steps as the manual setup below. You can switch between methods at any point or use the manual guide as a reference.
 </Callout>
 
-For more information, see the [GenLayer Skills plugin repository](https://github.com/genlayerlabs/skills).
+Browse all available skills at [skills.genlayer.com](https://skills.genlayer.com/) — the marketplace also includes the `genlayer-dev` skill for contract development.
 
 ---
 


### PR DESCRIPTION
## Summary

Elevates [GenLayer Skills](https://skills.genlayer.com/) to a first-class entry point across the docs. Previously, Skills was mentioned in only two places — one of them buried inside an "Agent-Assisted Development" section near the bottom of the tooling-setup page — and \`skills.genlayer.com\` (the canonical URL) was not linked anywhere; only the GitHub repo was.

> Stacks on top of #409 (agentic-adjudication-narrative). Targeting \`main\` — once #409 merges, this will fast-forward cleanly.

## Changes

- **Top-level nav** — adds a persistent \`Skills 🤖\` link to the top nav (\`pages/_meta.json\`), mirroring the existing Blog link.
- **Homepage** (\`pages/index.mdx\`) — Callout above the "Get Started" cards with install commands for both \`genlayer-dev\` and \`genlayernode\`.
- **Developer landing page** (\`pages/developers.mdx\`) — new "Start with Skills (Recommended)" section above the reference card grid. The card grid is reframed as the manual/reference path.
- **Tooling Setup** (\`pages/developers/intelligent-contracts/tooling-setup.mdx\`) — promotes Skills to the top of the page (right after the intro). The previous mention inside "Agent-Assisted Development" is replaced with a back-reference; MCP-server content stays.
- **Validator Setup** (\`pages/validators/setup-guide.mdx\`) — the see-more link at the bottom of "Option 1: AI-Assisted Setup" now points to \`skills.genlayer.com\` and surfaces cross-skill discoverability (mentions \`genlayer-dev\` alongside \`genlayernode\`).

All Skills links now point to \`skills.genlayer.com\` (canonical), not \`github.com/genlayerlabs/skills\`.

## Test plan

- [ ] \`pnpm dev\`, verify the \`Skills 🤖\` link appears in the top nav on every page and opens \`skills.genlayer.com\` in a new tab
- [ ] Homepage Callout renders with the install commands
- [ ] Developer landing page leads with the Skills section above the card grid
- [ ] Tooling-setup page leads with Skills before "Quick Start: GenLayer Studio"
- [ ] Validator setup guide shows the new \`skills.genlayer.com\` link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded FAQ with enhanced explanations of GenLayer's core concepts and positioning
  * Restructured use cases documentation into four organized categories
  * Added new glossary terms and expanded existing definitions
  * Updated developer getting started guides with new Skills onboarding pathway
  * Enhanced landing page and protocol documentation with clarified messaging

* **Chores**
  * Updated site SEO metadata and navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-docs/pull/410)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->