### PR TITLE
fix: remove /developers redirect so landing page renders

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -64,8 +64,7 @@ const previousRedirects = [
 ];
 
 const actualRedirects = [
-  { old: "/getting-started", new: "/developers/intelligent-contracts/introduction" },
-  { old: "/developers", new: "/developers/intelligent-contracts/introduction" },
+  { old: "/getting-started", new: "/developers" },
   { old: "/developers/intelligent-contracts/intro", new: "/developers/intelligent-contracts/introduction" },
 
   { old: "/overview", new: "/understand-genlayer-protocol" },


### PR DESCRIPTION
## Summary

The \`/developers\` route was redirecting to \`/developers/intelligent-contracts/introduction\`, which made the \`pages/developers.mdx\` landing page completely unreachable — including the **"Start with Skills (Recommended)"** section added in #410.

Verified just now on prod: \`curl -sL https://docs.genlayer.com/developers\` follows a 308 and lands on \`/developers/intelligent-contracts/introduction\`, so the new Skills section never renders.

## Changes

- Remove the \`/developers → /developers/intelligent-contracts/introduction\` redirect.
- Retarget the \`/getting-started\` redirect (was previously pointing past the landing page) to \`/developers\`.

## Test plan

- [ ] \`curl -sLI https://docs.genlayer.com/developers\` returns HTTP 200, not 308
- [ ] The landing page shows "Start with Skills (Recommended)" before the card grid
- [ ] Top-nav "Build on GenLayer" link still works