### PR TITLE
Fix incorrect Windows command and add Chrome/Chromium label to clearing cache instructions

### DIFF
--- a/pages/developers/intelligent-contracts/tools/genlayer-studio/troubleshooting.mdx
+++ b/pages/developers/intelligent-contracts/tools/genlayer-studio/troubleshooting.mdx
@@ -7,7 +7,7 @@ The frontend may not load correctly due to caching issues or an outdated version
 
 ### Solution
 - **Refresh Frontend:** Simply reload the page in your browser.
-- **Clear Cache:** Clear your browser's cache by clicking on the left of your address bar -> Cookies and site data -> Manage on device site data -> Delete localhost.
+- **Clear Cache (Chrome/Chromium):** Clear your browser's cache by clicking on the left of your address bar -> Cookies and site data -> Manage on device site data -> Delete localhost.
 
 import Image from 'next/image'
  
@@ -33,7 +33,7 @@ The Studio may fail to start if some ports required for its operation are alread
      ```
    - **Windows:**
      ```cmd copy
-     netstat -aon | find <PORT_NUMBER>
+     netstat -aon | findstr <PORT_NUMBER>
      ```
 2. Use the following command to kill the process using the port. Replace `<PID>` with the Process ID obtained from the previous step.
    - **Linux / MacOS:**


### PR DESCRIPTION
Closes #413

**Bug 1: Incorrect Windows command**
- Changed ind to indstr in Windows port conflict resolution command
- ind requires quoted search strings and cannot filter port numbers correctly on Windows

**Bug 2: Chrome-specific instructions not labeled**
- Added "(Chrome/Chromium)" label to the cache clearing instructions
- The "Click on the left of your address bar -> Cookies and site data..." steps only work on Chrome/Chromium, not Firefox, Brave, or Safari

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified browser cache clearing instructions for Chrome/Chromium with step-by-step navigation path.
  * Improved Windows port-conflict troubleshooting command for better accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-docs/pull/414)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->