### PR TITLE
[codex] repair docs MCP indexing

### DIFF
--- a/docs-mcp/Dockerfile
+++ b/docs-mcp/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:20-slim
+FROM node:22-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 make g++ && \
-    npm install -g @arabold/docs-mcp-server@2.0.4 && \
+    npm install -g @arabold/docs-mcp-server@2.4.0 && \
     apt-get purge -y python3 make g++ && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
@@ -10,6 +10,7 @@ RUN apt-get update && \
 ENV PORT=8080
 ENV DOCS_URL=https://docs.genlayer.com
 ENV SDK_URL=https://sdk.genlayer.com/main/
+ENV DOCS_MCP_SERVER_HEARTBEAT_MS=10000
 
 EXPOSE 8080
 

--- a/docs-mcp/entrypoint.sh
+++ b/docs-mcp/entrypoint.sh
@@ -2,19 +2,53 @@
 set -e
 
 STORE_PATH="${STORE_PATH:-/data}"
+MAX_PAGES="${MAX_PAGES:-1000}"
+MAX_DEPTH="${MAX_DEPTH:-8}"
 
-# Initial index if database doesn't exist
+index_docs() {
+  echo "Indexing documentation..."
+  docs-mcp-server scrape genlayer-docs "$DOCS_URL" \
+    --store-path "$STORE_PATH" \
+    --scope hostname \
+    --scrape-mode fetch \
+    --max-pages "$MAX_PAGES" \
+    --max-depth "$MAX_DEPTH" \
+    --exclude-pattern '/full-documentation\.txt/' \
+    --exclude-pattern '/developers/intelligent-contracts/?$/' \
+    --exclude-pattern '/understand-genlayer-protocol/consensus/?$/' \
+    --exclude-pattern '/validators/?$/'
+  docs-mcp-server scrape genlayer-sdk "$SDK_URL" \
+    --store-path "$STORE_PATH" \
+    --scope hostname \
+    --scrape-mode fetch \
+    --max-pages "$MAX_PAGES" \
+    --max-depth "$MAX_DEPTH"
+}
+
+index_is_usable() {
+  docs-mcp-server --quiet find-version genlayer-docs --store-path "$STORE_PATH" >/dev/null 2>&1 &&
+    docs-mcp-server --quiet find-version genlayer-sdk --store-path "$STORE_PATH" >/dev/null 2>&1
+}
+
 if [ ! -f "$STORE_PATH/documents.db" ]; then
-  echo "First boot — indexing documentation..."
-  docs-mcp-server scrape genlayer-docs "$DOCS_URL" --store-path "$STORE_PATH" --scope hostname --scrape-mode fetch --exclude-pattern "/full-documentation\.txt/"
-  docs-mcp-server scrape genlayer-sdk "$SDK_URL" --store-path "$STORE_PATH" --scope hostname --scrape-mode fetch
-  echo "Initial indexing complete."
+  echo "No index found at $STORE_PATH/documents.db"
+  index_docs
+elif ! index_is_usable; then
+  echo "Existing index at $STORE_PATH/documents.db is not usable; rebuilding..."
+  index_docs
 else
-  echo "Existing index found at $STORE_PATH/documents.db"
+  echo "Usable index found at $STORE_PATH/documents.db"
 fi
 
+echo "Verifying index..."
+if ! index_is_usable; then
+  echo "Index verification failed." >&2
+  exit 1
+fi
+echo "Index verification complete."
+
 echo "Starting docs-mcp-server..."
-exec docs-mcp-server server \
+exec docs-mcp-server mcp \
   --port "$PORT" \
   --host 0.0.0.0 \
   --store-path "$STORE_PATH" \

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,7 +6,7 @@
 
 - [Full Documentation](https://docs.genlayer.com/full-documentation.txt): Complete documentation in a single file
 - [Developers Guide](https://docs.genlayer.com/developers): Build on GenLayer
-- [Validators Guide](https://docs.genlayer.com/validators): Run a validator node
+- [Validators Guide](https://docs.genlayer.com/validators/setup-guide): Run a validator node
 
 ## API References
 
@@ -19,6 +19,6 @@
 
 ## Key Concepts
 
-- [Intelligent Contracts](https://docs.genlayer.com/developers/intelligent-contracts): Contracts that can access the web and use LLMs
-- [Equivalence Principle](https://docs.genlayer.com/understand-genlayer-protocol/consensus): How validators reach consensus on nondeterministic outputs
+- [Intelligent Contracts](https://docs.genlayer.com/developers/intelligent-contracts/introduction): Contracts that can access the web and use LLMs
+- [Equivalence Principle](https://docs.genlayer.com/understand-genlayer-protocol/core-concepts/optimistic-democracy/equivalence-principle): How validators reach consensus on nondeterministic outputs
 - [Staking](https://docs.genlayer.com/developers/staking-guide): Validator and delegator staking guide


### PR DESCRIPTION
## What changed
- Upgrade the docs MCP image to Node 22 and `@arabold/docs-mcp-server@2.4.0`.
- Add startup index verification and automatic rebuild when the persisted DB is unusable.
- Start the MCP-only server command and add a shorter SSE heartbeat.
- Fix broken `public/llms.txt` docs links that were poisoning scraper seed discovery.

## Why
The hosted MCP endpoint accepted sessions, but searches failed because the persisted index listed libraries while `search_docs`/`find_version` could not resolve them. The scraper could also fail while rebuilding because `llms.txt` contained links to routes that do not exist.

## Validation
- `sh -n docs-mcp/entrypoint.sh`
- `docker build -t genlayer-docs-mcp:test docs-mcp`
- Verified built image reports Node `v22.22.3` and docs-mcp-server `2.4.0`.
- Capped docs scrape with production excludes succeeded and `find-version` reported usable unversioned docs.
- Capped SDK scrape succeeded and `find-version` reported usable unversioned docs.
- Checked `public/llms.txt` `docs.genlayer.com` links against local page files.