### PR TITLE
Fix homepage title rendering

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,9 +1,13 @@
+---
+breadcrumb: false
+---
+
 import Image from 'next/image'
 import { Card, Cards } from 'nextra-theme-docs'
 import { Callout } from 'nextra-theme-docs'
 import CustomCard from '../components/card'
 
-## The Adjudication Layer for the Agentic Economy
+# The Adjudication Layer for the Agentic Economy
 
 GenLayer uses decentralized AI-validator consensus to resolve contracts that require judgment, not just code.
 


### PR DESCRIPTION
## Summary
- promote the homepage headline to an H1
- hide the homepage breadcrumb so the small meta title does not render above the hero headline

## Verification
- pnpm build
- browser check at http://localhost:3000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated page title hierarchy and disabled breadcrumb navigation for improved layout presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-docs/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->