### PR TITLE
docs: clarify testnet faucet ETH prerequisite

### DIFF
--- a/pages/developers/intelligent-contracts/deploying/network-configuration.mdx
+++ b/pages/developers/intelligent-contracts/deploying/network-configuration.mdx
@@ -94,6 +94,10 @@ genlayer deploy --contract contracts/my_contract.py
 
 Before deploying to TestnetBradbury, you'll need testnet tokens. Use the [faucet](https://testnet-faucet.genlayer.foundation/) to get free GEN tokens.
 
+<Callout emoji="💧">
+  The faucet may require your wallet to hold at least `0.01 ETH` as an anti-drain check. The ETH is not spent; it only needs to be present in the wallet you are using to claim testnet GEN.
+</Callout>
+
 ### Using TestnetBradbury
 
 ```bash

--- a/pages/developers/networks.mdx
+++ b/pages/developers/networks.mdx
@@ -9,6 +9,10 @@ For the full RPC reference, see [GenLayer Node API](/api-references/genlayer-nod
 
 Your wallet connects to the **GenLayer RPC** — it handles both intelligent contract calls and standard Ethereum methods.
 
+<Callout emoji="💧">
+  The Bradbury and Asimov faucet may require your wallet to hold at least `0.01 ETH` as an anti-drain check before it lets you claim testnet GEN. The ETH is not spent by the faucet; it only needs to be present in the same wallet.
+</Callout>
+
 ---
 
 ## Testnet Bradbury


### PR DESCRIPTION
## Summary
- Add a faucet prerequisite callout to the Networks page for Bradbury and Asimov.
- Add the same note to the TestnetBradbury token setup section.
- Clarify that the 0.01 ETH balance is an anti-drain check and is not spent by the faucet.

## Evidence basis
- Sanitized weekly support review found recent builder confusion about the testnet faucet requiring a wallet to hold 0.01 ETH before claiming GEN.
- The team clarified that this is expected anti-drain behavior: the ETH only needs to be present in the wallet and is not consumed.
- Existing docs linked the faucet but did not explain this prerequisite near the main faucet references.

## Test plan
- [x] `pnpm build`

Created by weekly docs-and-skills gap loop; draft for human review.