### PR TITLE
fix: update deprecated ContractRollback to gl.UserError in docs

### DIFF
--- a/pages/api-references/genlayer-test/direct.md
+++ b/pages/api-references/genlayer-test/direct.md
@@ -259,7 +259,7 @@ Stop the current prank.
 
 Context manager expecting the next call to revert.
 
-Catches ContractRollback (gl.rollback) and any Exception raised
+Catches gl.UserError and any Exception raised
 by contract code (ValueError, RuntimeError, etc.). If *message*
 is given, the exception text must contain it.
 


### PR DESCRIPTION
## Summary

Updates deprecated API reference `ContractRollback (gl.rollback)` to the current `gl.UserError` in the genlayer-test documentation.

## Related Issue

Closes #346 (partial fix)

## Changes

- Updated `pages/api-references/genlayer-test/direct.md`: replaced `ContractRollback (gl.rollback)` with `gl.UserError` to reflect the current SDK API

## Notes

This is part of a broader cleanup of deprecated API names identified in issue #346.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation for the `expect_revert` method to clarify the exception types caught during test validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->