### PR TITLE
docs: clarify Studionet vs Bradbury in Studio

### DIFF
--- a/pages/developers/intelligent-contracts/tools/genlayer-studio.mdx
+++ b/pages/developers/intelligent-contracts/tools/genlayer-studio.mdx
@@ -6,7 +6,16 @@ import { Card, Cards, Callout, Bleed } from 'nextra-theme-docs'
 
 # GenLayer Studio
 
-GenLayer Studio is an interactive sandbox where developers explore the potential of GenLayer's Intelligent Contracts. It replicates the GenLayer network's execution environment and consensus algorithm, but offers a controlled and local environment to test different ideas and behaviors.
+GenLayer Studio is an interactive sandbox where developers explore the potential of GenLayer's Intelligent Contracts. It replicates the GenLayer network's execution environment and consensus algorithm, but offers a controlled environment to test different ideas and behaviors.
+
+You can use Studio in two common ways:
+
+- **Hosted Studionet:** Open [studio.genlayer.com](https://studio.genlayer.com/) in your browser. This is the fastest way to try contracts, use Studio features such as logs, validators, and the built-in faucet, and complete browser-wallet onboarding flows that ask you to add the Studio network.
+- **Local Studio:** Run Studio locally when you need full control over your development environment.
+
+<Callout type="info">
+  Studionet and Bradbury are different networks. Use **Studionet** for hosted Studio features and the built-in Studio faucet. Use **Bradbury** when you are ready for production-like testnet deployments with persistent state; Bradbury uses the public testnet faucet and network details on the [Networks](/developers/networks) page.
+</Callout>
 
 ### What you can do with the GenLayer Studio:
 


### PR DESCRIPTION
## Summary
- Clarifies that hosted Studio uses Studionet while Bradbury is the production-like persistent testnet.
- Points builders to the built-in Studio faucet/features for Studionet and the public Networks page for Bradbury details.

## Sanitized evidence basis
Recent builder-support messages repeatedly asked for the correct network details for browser-wallet onboarding, whether Studio features such as logs/validators/faucet apply to testnet, and how to distinguish Bradbury from the Studio network. The existing Studio page described Studio as local/sandbox-focused and did not make this distinction explicit.

## Test plan
- `pnpm build` — passed.

Created by weekly docs-and-skills gap loop; draft for human review.