### PR TITLE
docs: clarify GenLayerJS wallet provider flow

### DIFF
--- a/pages/api-references/genlayer-js.md
+++ b/pages/api-references/genlayer-js.md
@@ -168,6 +168,8 @@ console.log(trace.genvm_log);    // detailed GenVM execution logs
 
 When building a browser dApp, create two clients: one for reads (no wallet needed) and one for writes (signed by the wallet). This follows the standard viem pattern and keeps concerns separated.
 
+GenLayerJS can sign browser transactions through a standard EIP-1193 wallet provider such as `window.ethereum`. The SDK does not require a MetaMask Snap for this flow. If your app also integrates a separate GenLayer wallet plugin or Snap, treat it as a separate wallet integration path and make it explicit in your UI so users understand why the browser is showing Snap or third-party-wallet warnings.
+
 ```typescript
 import { createClient } from "genlayer-js";
 import { testnetBradbury } from "genlayer-js/chains";
@@ -237,6 +239,15 @@ const txHash = await client.writeContract({
 Available networks: `"localnet"`, `"studionet"`, `"testnetAsimov"`, `"testnetBradbury"`.
 
 > **Note:** If the wallet is on the wrong chain when you call `writeContract`, the SDK will throw a clear error telling you which chain the wallet is on vs. which chain the client expects. Call `client.connect()` to resolve this.
+
+### Wallet provider troubleshooting
+
+If users report that a dApp is asking for the GenLayer wallet plugin, a MetaMask Snap, or that another wallet extension such as Rabby must be disabled, first check which provider your app is passing to GenLayerJS:
+
+- For the standard SDK flow, pass the selected wallet's EIP-1193 provider, for example `provider: window.ethereum`, and call `client.connect()` before writing.
+- Do not assume `window.ethereum` always points to MetaMask when several wallet extensions are installed. Use your wallet connector's selected provider when possible.
+- If you intentionally depend on a Snap or wallet plugin, tell users this is an app-level wallet requirement, not a requirement of `writeContract` itself.
+- Keep a read-only client without a wallet provider for `readContract`, `getTransaction`, and receipt polling so read paths still work when the wallet is disconnected or on the wrong chain.
 
 ### Staking Operations
 

--- a/pages/developers/decentralized-applications/writing-data.mdx
+++ b/pages/developers/decentralized-applications/writing-data.mdx
@@ -135,6 +135,7 @@ import { TransactionStatus } from "genlayer-js/types";
 const client = createClient({
   chain: studionet,
   account: walletAddress as `0x${string}`,
+  provider: window.ethereum,
 });
 
 // Switch the wallet to the correct network — must be called before writing
@@ -157,6 +158,8 @@ const receipt = await client.waitForTransactionReceipt({
 Available networks: `"localnet"`, `"studionet"`, `"testnetAsimov"`, `"testnetBradbury"`.
 
 > **Important:** If the wallet is on the wrong chain, the SDK will throw an error telling you which chain the wallet is on vs. which chain the client expects. Always call `client.connect()` before sending transactions.
+
+> **Wallet provider note:** The standard GenLayerJS browser flow uses the selected wallet's EIP-1193 provider, such as `window.ethereum`; it does not require a MetaMask Snap by itself. If your dApp asks users to install a GenLayer wallet plugin or Snap, that requirement comes from the wallet integration you chose, so document it in your app UI and make sure you pass the intended provider when multiple wallet extensions are installed.
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary
- Clarifies that the standard GenLayerJS browser write flow uses an EIP-1193 wallet provider and does not require a MetaMask Snap by itself.
- Adds wallet-provider troubleshooting guidance for multi-wallet extension setups and app-level Snap/plugin requirements.
- Updates the dApp writing guide example to pass the browser wallet provider explicitly.

## Sanitized evidence basis
Recent builder support discussion showed confusion about whether `genlayer-js` writes require the GenLayer wallet plugin / MetaMask Snap and whether wallet-extension conflicts such as Rabby are expected. Current docs showed `window.ethereum` in the API reference but did not explicitly separate the standard SDK provider flow from optional Snap/plugin integrations.

## Test plan
- `git diff --check`
- `pnpm build`

Note: Created by weekly docs-and-skills gap loop; draft for human review.