### PR TITLE
ci: drop node.dev sanitization step (after genlayer-node NOD-973)

### DIFF
--- a/.github/scripts/sanitize-config.sh
+++ b/.github/scripts/sanitize-config.sh
@@ -20,13 +20,11 @@ fi
 echo "Sanitizing config file: $CONFIG_FILE"
 
 # Use yq to:
-# 1. Replace RPC URLs with TODO placeholders
-# 2. Delete node.dev section
+# Replace RPC URLs / provider with TODO placeholders
 yq -i '
   .rollup.genlayerchainrpcurl = "TODO: Set your GenLayer Chain ZKSync HTTP RPC URL here" |
   .rollup.genlayerchainwebsocketurl = "TODO: Set your GenLayer Chain ZKSync WebSocket RPC URL here" |
-  .rollup.provider = "TODO: Set your GenLayer Chain ZKSync provider" |
-  del(.node.dev)
+  .rollup.provider = "TODO: Set your GenLayer Chain ZKSync provider"
 ' "$CONFIG_FILE"
 
 echo "Config sanitization completed"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -181,13 +181,12 @@ The workflow uses composite actions for code reusability:
 - `.github/scripts/git-utils.sh` - Branch creation, commit, and push operations
 - `.github/scripts/version-utils.sh` - Version detection and validation
 - `.github/scripts/doc-generator.sh` - Wrapper for npm documentation generation
-- `.github/scripts/sanitize-config.sh` - Sanitizes config file (replaces URLs, removes dev section)
+- `.github/scripts/sanitize-config.sh` - Sanitizes config file (replaces URLs)
 - `.github/scripts/sanitize-docker-compose.sh` - Removes alloy service and volumes from docker-compose
 
 ### Config Sanitization
 The config sync process includes automatic sanitization using `yq`:
-- **URL Replacement**: RPC URLs replaced with TODO placeholders
-- **Dev Section Removal**: `node.dev` section is removed
+- **URL Replacement**: RPC URLs and provider replaced with TODO placeholders
 
 ### Docker Compose Sanitization
 The docker-compose sync process includes automatic sanitization using `yq` and `sed`:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -181,7 +181,7 @@ The workflow uses composite actions for code reusability:
 - `.github/scripts/git-utils.sh` - Branch creation, commit, and push operations
 - `.github/scripts/version-utils.sh` - Version detection and validation
 - `.github/scripts/doc-generator.sh` - Wrapper for npm documentation generation
-- `.github/scripts/sanitize-config.sh` - Sanitizes config file (replaces URLs)
+- `.github/scripts/sanitize-config.sh` - Sanitizes config file (replaces RPC URLs and provider)
 - `.github/scripts/sanitize-docker-compose.sh` - Removes alloy service and volumes from docker-compose
 
 ### Config Sanitization


### PR DESCRIPTION
## ⚠️ DO NOT MERGE before genlayer-node NOD-973 lands on `v0.6`

Merging this early would **leak the un-sanitized `node.dev` section into the published docs config**. Until NOD-973 merges, upstream `config.yaml.example` still ships `node.dev`, so our `del(.node.dev)` is still doing real sanitization. This PR is only safe to merge once `node.dev` is gone from the synced source.

## What

genlayer-node [NOD-973](https://linear.app/genlayer) removes the `node.dev` section entirely from `config.yaml.example`. Its only field was `disableSubscription` (a test-only toggle for zksync-anvil). Once removed upstream, our `del(.node.dev)` in the config sanitizer deletes a non-existent path — dead config.

## Changes

- `.github/scripts/sanitize-config.sh` — drop the `del(.node.dev)` step and the now-trailing yq pipe (`|`) it dangled off. RPC-URL + provider placeholder substitutions are unrelated and unchanged.
- `.github/workflows/README.md` — remove the two stale references to "removes dev section" / "Dev Section Removal".

## Coordination

Confirmed sequencing with the genlayer-node session working NOD-973 (handoff, 2026-06-29). They'll signal when it lands on `v0.6`; this PR should merge after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized config output now preserves development-related settings instead of removing them.
  * Sensitive RPC and provider values are still replaced with placeholder text during sanitization.

* **Documentation**
  * Updated workflow documentation to match the new sanitization behavior and placeholder replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->