### PR TITLE
fix: correct Windows netstat command and add browser label for cache clearing

### DIFF
--- a/pages/developers/intelligent-contracts/tools/genlayer-studio/troubleshooting.mdx
+++ b/pages/developers/intelligent-contracts/tools/genlayer-studio/troubleshooting.mdx
@@ -11,7 +11,7 @@ The frontend may not load correctly due to caching issues or an outdated version
 
 ### Solution
 - **Refresh Frontend:** Simply reload the page in your browser.
-- **Clear Cache:** Clear your browser's cache by clicking on the left of your address bar -> Cookies and site data -> Manage on device site data -> Delete localhost.
+- **Clear Cache (Chrome/Chromium):** Clear your browser's cache by clicking on the left of your address bar -> Cookies and site data -> Manage on device site data -> Delete localhost. For other browsers (Firefox, Brave, Safari), use the browser's built-in settings to clear site data for localhost.
 
 import Image from 'next/image'
  
@@ -37,7 +37,7 @@ The Studio may fail to start if some ports required for its operation are alread
      ```
    - **Windows:**
      ```cmd copy
-     netstat -aon | find <PORT_NUMBER>
+     netstat -aon | findstr <PORT_NUMBER>
      ```
 2. Use the following command to kill the process using the port. Replace `<PID>` with the Process ID obtained from the previous step.
    - **Linux / MacOS:**


### PR DESCRIPTION
## Summary

Two fixes in the Studio troubleshooting documentation.

## Bug 1: Wrong Windows Command

The port conflict section used `find` instead of `findstr`:

```cmd
# Before (broken on Windows)
netstat -aon | find <PORT_NUMBER>

# After (correct)
netstat -aon | findstr <PORT_NUMBER>
```

The `find` command on Windows requires quoted search strings and behaves differently from Unix `grep`. `findstr` is the correct tool for filtering `netstat` output by port number.

## Bug 2: Chrome-Only Cache Instructions Not Labeled

The cache clearing steps (`address bar -> Cookies and site data -> Manage on device site data -> Delete localhost`) only work in Chrome/Chromium. Firefox, Brave, and Safari users cannot find these options.

Added `(Chrome/Chromium)` label and a note directing other browser users to their browser's built-in site data settings.

Fixes #413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded browser-specific instructions for clearing localhost cache and site data when the frontend does not load correctly.
  * Updated the Windows port-conflict troubleshooting command to improve process identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->