### PR TITLE
fix(docs): correct case of consensus diagram image path (404 on case-sensitive hosting)

### DIFF
--- a/pages/understand-genlayer-protocol.mdx
+++ b/pages/understand-genlayer-protocol.mdx
@@ -35,7 +35,7 @@ This architecture supports autonomous DAOs, self-executing prediction markets, a
 
 Optimistic Democracy is GenLayer's consensus mechanism for merging probabilistic AI systems with deterministic blockchain rules so the network can reach secure and accurate consensus at scale. Inspired by **[Condorcet's Jury Theorem](https://jury-theorem.genlayer.com/)** (click the link to check out our interactive model), the process uses validator recomputation and majority agreement as a safety net for AI-driven computations.
 
-<img src="/studio/Diagram MAIN.jpg" alt="GenLayer Optimistic Democracy Consensus Diagram" width="100%" />
+<img src="/studio/diagram main.jpg" alt="GenLayer Optimistic Democracy Consensus Diagram" width="100%" />
 
 1. **User Submits a Transaction**
 A user sends a transaction request to the network (see the diagram's Step 1).


### PR DESCRIPTION
## Problem

On the **Understand GenLayer Protocol** page, the Optimistic Democracy consensus diagram is referenced as:

```mdx
<img src="/studio/Diagram MAIN.jpg" alt="GenLayer Optimistic Democracy Consensus Diagram" width="100%" />
```

but the committed asset is `public/studio/diagram main.jpg` (all lowercase).

Because the reference case (`Diagram MAIN.jpg`) doesn't match the file on disk (`diagram main.jpg`), the image resolves fine on case-insensitive filesystems (macOS/Windows dev machines) but **returns a 404 on case-sensitive hosting** (the Linux/Netlify production build). The result is a broken hero diagram on one of the core concept pages.

For reference, the other image on the site is referenced with the correct lowercase path already, e.g. `debugging.mdx` uses `/studio/syntax-error.png`.

## Fix

Update the `src` in `pages/understand-genlayer-protocol.mdx` to match the actual filename:

```diff
-<img src="/studio/Diagram MAIN.jpg" alt="GenLayer Optimistic Democracy Consensus Diagram" width="100%" />
+<img src="/studio/diagram main.jpg" alt="GenLayer Optimistic Democracy Consensus Diagram" width="100%" />
```

One-line, non-breaking change; the asset itself is unchanged.

## Testing

- Verified the referenced file exists at `public/studio/diagram main.jpg` (lowercase) and that no file named `Diagram MAIN.jpg` exists in the repo.
- The corrected path now matches the committed asset exactly, so it will resolve on case-sensitive production hosting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the consensus diagram shown in the “Optimistic Democracy: How Consensus Works” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->