### PR TITLE
docs(genlayer-js): document where consensus results live on a transaction

### DIFF
--- a/pages/api-references/genlayer-js/transactions.md
+++ b/pages/api-references/genlayer-js/transactions.md
@@ -94,3 +94,45 @@ Estimates gas required for a transaction.
 
 ---
 
+
+## Reading consensus results
+
+`getTransaction` returns consensus details, but the fields most people need are
+nested and easy to miss. On a decided transaction:
+
+| Field | Meaning |
+|-------|---------|
+| `resultName` | The consensus verdict, e.g. `AGREE`. |
+| `txExecutionResultName` | What the code did, e.g. `FINISHED_WITH_RETURN`, `FINISHED_WITH_ERROR`. |
+| `lastRound.validatorVotes` | Per-validator vote vector, e.g. `[1, 1, 1, 1, 1]`. |
+| `lastRound.validatorVotesName` | The same votes as labels, e.g. `AGREE` / `DISAGREE`. |
+| `lastRound.votesCommitted` / `lastRound.votesRevealed` | Vote counts for the round. |
+| `lastRound.validatorResultHash` | Per-validator result hashes; compare them to detect a split. |
+| `txDataDecoded.contractAddress` | Contract address after a deploy. |
+
+Reading `resultName` alone is not enough to know a run was healthy. A
+transaction can be `ACCEPTED` while validators split underneath, and it can be
+`ACCEPTED` with every validator agreeing that the contract *raised*. Inspect the
+vote vector and `txExecutionResultName` together.
+
+### Statuses seen while polling
+
+`COMMITTING` and `REVEALING` are in-flight. `ACCEPTED`, `FINALIZED`,
+`UNDETERMINED` and `CANCELED` are decided. A numeric `status` value that has no
+name in your SDK version (for example `14`) is a transient state, not an error:
+keep polling rather than treating it as a failure.
+
+### Do not reach for an EVM receipt helper
+
+`getTransactionReceipt` from a generic EVM client returns "not found" for
+GenLayer transactions. Use `getTransaction`.
+
+### Allow a deploy to settle before calling a write method
+
+Calling a write method immediately after a successful deploy can revert at the
+EVM level against the consensus contract, even when the deploy itself returned a
+unanimous AGREE. The same call to the same contract address succeeds once the
+deploy has settled. If you are scripting deploy-then-write cycles, insert a
+short wait between the two rather than chaining them directly.
+
+---

--- a/pages/api-references/genlayer-js/transactions.md
+++ b/pages/api-references/genlayer-js/transactions.md
@@ -119,20 +119,26 @@ vote vector and `txExecutionResultName` together.
 
 `COMMITTING` and `REVEALING` are in-flight. `ACCEPTED`, `FINALIZED`,
 `UNDETERMINED` and `CANCELED` are decided. A numeric `status` value that has no
-name in your SDK version (for example `14`) is a transient state, not an error:
-keep polling rather than treating it as a failure.
+name in your SDK version (for example `14`) has been observed as a transient
+state rather than an error: keep polling rather than treating it as a failure.
 
-### Do not reach for an EVM receipt helper
+### A generic EVM receipt helper will not find the transaction
 
-`getTransactionReceipt` from a generic EVM client returns "not found" for
-GenLayer transactions. Use `getTransaction`.
+`getTransactionReceipt` from a generic EVM client (for example Viem's) returns
+"not found" for GenLayer transactions. Use genlayer-js's `getTransaction`. This
+note is about the EVM client's method, not about genlayer-js's own
+`waitForTransactionReceipt`, which is supported.
 
-### Allow a deploy to settle before calling a write method
+### A write fired right after a deploy may revert
 
-Calling a write method immediately after a successful deploy can revert at the
-EVM level against the consensus contract, even when the deploy itself returned a
-unanimous AGREE. The same call to the same contract address succeeds once the
-deploy has settled. If you are scripting deploy-then-write cycles, insert a
-short wait between the two rather than chaining them directly.
+Calling a write method seconds after a successful deploy can revert at the EVM
+level against the consensus contract, even when the deploy itself returned a
+unanimous AGREE. We observed this ~2.2s after a deploy, with the identical call
+to the identical address succeeding after a wait.
+
+Treat it as a flake to retry through rather than something a delay reliably
+prevents: we have also seen this revert occur with a 25 second post-deploy
+delay. The practical point is that a revert here may have nothing to do with
+your contract logic, so it is not the first place to look.
 
 ---


### PR DESCRIPTION
## What

Adds a **Reading consensus results** section to the genlayer-js transaction
reference, documenting where the consensus fields actually live on a returned
transaction, plus four practical notes.

## Why

The page currently says `getTransaction` "Fetches transaction data including
status, execution result, and consensus details" — but does not say where those
consensus details are. Finding them took a debugging session: the votes are
nested under `lastRound` (`validatorVotes`, `validatorVotesName`,
`votesCommitted` / `votesRevealed`, `validatorResultHash`), the verdict is
`resultName`, and the execution outcome is `txExecutionResultName`.

The section also records three behaviours that are easy to get wrong and are not
documented anywhere I could find:

1. **`resultName` alone does not mean the run was healthy.** A transaction can
   be `ACCEPTED` while validators split underneath, and it can be `ACCEPTED`
   with every validator agreeing that the contract *raised*. You need the vote
   vector and `txExecutionResultName` together.
2. **A numeric `status` with no name in your SDK version (e.g. `14`) is
   transient, not an error.** Treating it as a failure aborts runs that would
   have succeeded on the next poll.
3. **A write method called immediately after a successful deploy can revert at
   the EVM level** against the consensus contract, even when the deploy returned
   a unanimous AGREE. The same call to the same address succeeds once the deploy
   has settled. Anyone scripting deploy-then-write cycles hits this and it looks
   like a contract bug.

Also notes that a generic EVM `getTransactionReceipt` returns "not found" for
GenLayer transactions, since that is a natural thing to reach for.

## How this was found

While building and measuring Intelligent Contracts on the bradbury testnet. The
deploy-then-write revert was observed at ~2.2s after a `{AGREE: 5}` deploy, and
the identical call to the identical contract address succeeded after a wait.

Happy to adjust wording, placement, or trim anything that duplicates docs I did
not find.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section on interpreting consensus results returned by `getTransaction`, including validator vote details and execution outcomes.
  * Clarified transaction polling states, distinguishing in-progress vs decided outcomes and noting transient numeric status values.
  * Documented which nested fields to inspect and how to decode the deployed contract address.
  * Added warnings that generic EVM receipt helpers may not work for GenLayer transactions and that post-deploy writes may temporarily fail even after successful consensus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->