### PR TITLE
docs: add Studio storage budget guidance

### DIFF
--- a/pages/developers/intelligent-contracts/storage.mdx
+++ b/pages/developers/intelligent-contracts/storage.mdx
@@ -14,6 +14,18 @@ Usual data structures aren't suitable for representing blockchain persistent sto
 
 Intelligent Contracts store data publicly on chain, attached to their account's address. The storage starts zero-initialized until a contract is deployed and initializes a state.
 
+## Storage budgets and design guidelines
+
+Persistent contract storage is replicated and retained by the network, so design it as a scarce resource instead of an unbounded application database. On public Studio, contracts have a **256 MiB daily storage budget**; contracts that write unusually large amounts of data may receive quota errors. Existing contracts are not permanently locked when they hit the budget: the first write each UTC day is allowed.
+
+To keep contracts reliable and portable to future networks:
+
+- Keep histories bounded and retain only recent or essential entries.
+- Store large reports, logs, documents, or raw datasets off-chain, and keep hashes or references on-chain.
+- Update existing records when possible instead of appending indefinitely.
+- Use compact data structures and avoid duplicated JSON or text blobs.
+- Batch related updates where practical.
+
 For storage declaration GenLayer uses contract class fields.
 
 <Callout emoji="🚫">


### PR DESCRIPTION
## Summary
- Add public Studio's 256 MiB daily storage budget to the Intelligent Contract storage docs.
- Add concrete storage design guidance for bounded histories, off-chain large artifacts, compact structures, and batching.

## Sanitized evidence basis
- Recent public builder-facing announcement introduced the Studio storage budget and recommended design patterns.
- Current storage docs explained storage types and persistence, but did not mention the budget or quota-error design guidance.

## Test plan
- `pnpm build` — passed.

Created by weekly docs-and-skills gap loop; draft for human review.
