### PR TITLE
fix(docs-mcp): harden stateless production serving

### DIFF
--- a/.github/workflows/docs-mcp-health.yml
+++ b/.github/workflows/docs-mcp-health.yml
@@ -7,17 +7,68 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: docs-mcp-production-health
   cancel-in-progress: true
 
 jobs:
-  mcp-handshake:
+  mcp-canary:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v4
 
-      - name: Initialize MCP and list tools
+      - name: Validate stateless HTTP and Docs search quality
+        id: docs
+        continue-on-error: true
+        run: node docs-mcp/smoke-test.mjs https://docs-mcp.genlayer.com/mcp
+
+      - name: Validate SDK search quality
+        id: sdk
+        continue-on-error: true
+        env:
+          DOCS_MCP_SEARCH_LIBRARY: genlayer-sdk
+          DOCS_MCP_SEARCH_QUERY: manager socket protocol
+          DOCS_MCP_SEARCH_EXPECTED_TEXT: Manager Socket Protocol
+        run: node docs-mcp/smoke-test.mjs https://docs-mcp.genlayer.com/mcp
+
+      - name: Validate legacy SSE compatibility
+        id: legacy
+        continue-on-error: true
+        env:
+          DOCS_MCP_SKIP_SEARCH: "true"
         run: node docs-mcp/smoke-test.mjs https://docs-mcp.genlayer.com/sse
+
+      - name: Open or update incident issue
+        if: steps.docs.outcome == 'failure' || steps.sdk.outcome == 'failure' || steps.legacy.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="Docs MCP production canary is failing"
+          issue="$(gh issue list --state open --search "${title} in:title" --json number --jq '.[0].number // empty')"
+          body="The production protocol canary failed. Docs search: ${{ steps.docs.outcome }}. SDK search: ${{ steps.sdk.outcome }}. Legacy SSE: ${{ steps.legacy.outcome }}. Run: ${RUN_URL}"
+          if [[ -n "$issue" ]]; then
+            gh issue comment "$issue" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi
+
+      - name: Close recovered incident issue
+        if: steps.docs.outcome == 'success' && steps.sdk.outcome == 'success' && steps.legacy.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          title="Docs MCP production canary is failing"
+          issue="$(gh issue list --state open --search "${title} in:title" --json number --jq '.[0].number // empty')"
+          if [[ -n "$issue" ]]; then
+            gh issue close "$issue" --comment "Recovered in workflow run ${{ github.run_id }}."
+          fi
+
+      - name: Fail unhealthy canary
+        if: steps.docs.outcome == 'failure' || steps.sdk.outcome == 'failure' || steps.legacy.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/docs-mcp.yml
+++ b/.github/workflows/docs-mcp.yml
@@ -43,10 +43,24 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: ./docs-mcp
           push: ${{ github.event_name == 'push' }}
+          build-args: |
+            DOCS_REVISION=${{ github.sha }}
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:sha-${{ github.sha }}
+
+      - name: Record published release
+        if: github.event_name == 'push'
+        run: |
+          {
+            echo "### Docs MCP image published"
+            echo
+            echo "- Source: \`${{ github.sha }}\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- GitOps: \`genlayerlabs/devexp-argocd-apps\` polls the labeled \`latest\` image and promotes this digest"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs-mcp/Dockerfile
+++ b/docs-mcp/Dockerfile
@@ -1,20 +1,30 @@
 FROM node:22-slim
 
+ARG DOCS_MCP_SERVER_VERSION=3.0.1
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 make g++ && \
-    npm install -g @arabold/docs-mcp-server@2.4.0 && \
+    npm install -g "@arabold/docs-mcp-server@${DOCS_MCP_SERVER_VERSION}" && \
     apt-get purge -y python3 make g++ && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
+
+ARG DOCS_REVISION=unknown
+
+LABEL org.opencontainers.image.source="https://github.com/genlayerlabs/genlayer-docs" \
+      org.opencontainers.image.revision="${DOCS_REVISION}" \
+      org.genlayer.docs-mcp.server-version="${DOCS_MCP_SERVER_VERSION}"
 
 ENV PORT=8080
 ENV DOCS_URL=https://docs.genlayer.com
 ENV SDK_URL=https://sdk.genlayer.com/main/
 ENV DOCS_MCP_SERVER_HEARTBEAT_MS=10000
+ENV DOCS_REVISION=${DOCS_REVISION}
 
 EXPOSE 8080
 
 COPY entrypoint.sh /entrypoint.sh
+COPY smoke-test.mjs /opt/docs-mcp/smoke-test.mjs
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docs-mcp/OPERATIONS.md
+++ b/docs-mcp/OPERATIONS.md
@@ -2,58 +2,121 @@
 
 The Docs MCP service has three separately owned parts:
 
-- this repository builds and publishes the server image;
-- `genlayerlabs/devexp-apps-workload` deploys the image to Kubernetes through
-  ArgoCD;
-- `genlayerlabs/skills` exposes the public SSE endpoint from the
-  `genlayer-dev` plugin.
+- this repository builds and publishes the server image to GHCR;
+- `genlayerlabs/devexp-argocd-apps` deploys the production workload on AWS EKS;
+- `genlayerlabs/argocd-aws-apps` registers that workload with ArgoCD;
+- `genlayerlabs/skills` exposes the hosted connection through the GenLayer Docs plugin.
 
-Publishing an image is not a deployment. Production must reference an immutable
-`sha-<commit>` image tag (or digest) in the workload repository. A deployment is
-complete only after the new Kubernetes rollout succeeds and
-`smoke-test.mjs` completes an MCP `initialize` and `tools/list` exchange against
-the public endpoint.
+The primary endpoint is stateless Streamable HTTP at
+`https://docs-mcp.genlayer.com/mcp`. Legacy SSE remains available at `/sse` and
+`/messages` for clients that do not support Streamable HTTP yet.
 
-## Health check
+## Release and deployment flow
 
-Run the protocol-level canary:
+Merges to `main` that change `docs-mcp/**` or `pages/**` publish `latest` and
+`sha-<commit>` to GHCR. The image embeds the full source commit as the OCI
+`org.opencontainers.image.revision` label, so a docs-only change produces a new
+image digest even when the server files are unchanged.
+
+`devexp-argocd-apps` polls that labeled release, resolves its immutable digest,
+opens and auto-merges a one-line-or-two-line workload bump PR, and lets ArgoCD
+roll the StatefulSet. The deployment is complete only after:
+
+1. ArgoCD reports the exact GitOps revision synced and healthy;
+2. the workload is running the expected immutable digest;
+3. the public `/mcp` canary initializes without a session, lists tools, and runs
+   real `search_docs` queries against both indexes without duplicate
+   Markdown-mirror results or undefined result metadata; and
+4. the legacy `/sse` compatibility handshake still succeeds.
+
+The GitOps verification workflow restores the previous `docs-mcp` manifests
+when a rollout or public canary fails. Scheduled canary failures create or
+update an incident issue in this repository and close it after recovery.
+
+## Index lifecycle
+
+The AWS cluster provides EBS block storage, not a shared filesystem suitable
+for SQLite. Each StatefulSet pod therefore uses its own `emptyDir` volume:
+
+1. an init container scrapes `docs.genlayer.com` and `sdk.genlayer.com` into a
+   fresh local SQLite index;
+2. it verifies that both libraries are usable;
+3. the serving container starts read-only from that immutable local copy.
+
+The rolling update creates and readies one freshly indexed pod at a time. This
+avoids concurrent SQLite writers, removes the stale shared-PVC failure mode,
+and allows the two serving replicas to run on different nodes. The previous
+EBS PVC is intentionally retained, unmounted, for short-term rollback evidence;
+it is not part of the active data path.
+
+Rendered pages and their `.md` mirrors contain the same content. The scraper
+excludes `.md` URLs so each canonical page is indexed once.
+
+## Health checks
+
+Run the primary protocol and search-quality canary:
 
 ```bash
-node docs-mcp/smoke-test.mjs https://docs-mcp.genlayer.com/sse
+node docs-mcp/smoke-test.mjs https://docs-mcp.genlayer.com/mcp
 ```
 
-An HTTP-only `/healthz` check is insufficient. The production nginx sidecar can
-answer that route even when the MCP container is unavailable.
+Run the legacy compatibility canary without a duplicate search call:
+
+```bash
+DOCS_MCP_SKIP_SEARCH=true \
+  node docs-mcp/smoke-test.mjs https://docs-mcp.genlayer.com/sse
+```
+
+Run the SDK-index canary:
+
+```bash
+DOCS_MCP_SEARCH_LIBRARY=genlayer-sdk \
+DOCS_MCP_SEARCH_QUERY='manager socket protocol' \
+DOCS_MCP_SEARCH_EXPECTED_TEXT='Manager Socket Protocol' \
+  node docs-mcp/smoke-test.mjs https://docs-mcp.genlayer.com/mcp
+```
+
+An HTTP-only `/healthz` check is insufficient. The ingress health route proves
+that nginx can reach the MCP process, while the protocol canary proves that the
+server and index can answer real MCP traffic.
 
 ## Incident triage
 
-Check both the pod and the MCP container before restarting anything:
+Check ArgoCD, both StatefulSet pods, and their init-container logs before
+restarting anything:
 
 ```bash
-kubectl get pods -n studio-prd -l app=docs-mcp-server
-kubectl describe pod -n studio-prd -l app=docs-mcp-server
-kubectl logs -n studio-prd -l app=docs-mcp-server -c docs-mcp-server --tail=200
-kubectl logs -n studio-prd -l app=docs-mcp-server -c docs-mcp-server \
-  --previous --tail=200
-kubectl get events -n studio-prd --sort-by=.lastTimestamp
+kubectl --context devexp-prd -n argocd get application docs-mcp
+kubectl --context devexp-prd -n studio-prd get statefulset,pods \
+  -l app=docs-mcp-server
+kubectl --context devexp-prd -n studio-prd describe pod \
+  -l app=docs-mcp-server
+kubectl --context devexp-prd -n studio-prd logs \
+  -l app=docs-mcp-server -c index-docs --tail=200
+kubectl --context devexp-prd -n studio-prd logs \
+  -l app=docs-mcp-server -c docs-mcp-server --tail=200
+kubectl --context devexp-prd -n studio-prd get events \
+  --sort-by=.lastTimestamp
 ```
 
-Inspect PVC capacity and index size when logs mention SQLite, disk, migration,
-or verification errors. `documents.db` is derived data; the entrypoint removes
-an unusable database and rebuilds it from the configured docs sources.
+The index is derived data. A failed init container should be diagnosed from its
+scrape and verification output; deleting or repairing a shared database is no
+longer part of normal recovery.
 
-## Required deployment guardrails
+## Deployment guardrails
 
-The workload repository should:
+The production workload must continue to:
 
-1. pin an immutable image tag or digest;
-2. use a rolling deployment with at least two serving replicas;
-3. move indexing into a separate Job that writes a new index before rollout;
-4. make readiness and ingress health depend on the MCP process, not nginx;
-5. wait for rollout completion and run the public protocol canary;
-6. roll back automatically when the canary fails;
-7. alert the owning channel when the scheduled canary fails.
+1. pin immutable image digests;
+2. run at least two Streamable HTTP serving replicas with rolling updates and
+   one pod available throughout the rollout;
+3. build a fresh pod-local index before each server starts;
+4. route `/sse` and `/messages` to one stable StatefulSet pod while legacy
+   sessions are supported;
+5. make readiness and ingress health depend on the MCP process;
+6. wait for ArgoCD convergence and run both public protocol canaries;
+7. restore the previous manifests automatically when verification fails; and
+8. open an incident issue when the scheduled production canary fails.
 
 Do not restore the removed `POST /web/jobs/scrape` workflow call. That route is
-not exposed by the pinned `docs-mcp-server mcp` runtime. Refresh the index with a
-dedicated indexing Job instead.
+not exposed by the read-only `docs-mcp-server mcp` runtime.

--- a/docs-mcp/entrypoint.sh
+++ b/docs-mcp/entrypoint.sh
@@ -4,6 +4,15 @@ set -e
 STORE_PATH="${STORE_PATH:-/data}"
 MAX_PAGES="${MAX_PAGES:-1000}"
 MAX_DEPTH="${MAX_DEPTH:-8}"
+MAX_CONCURRENCY="${MAX_CONCURRENCY:-4}"
+MODE="${MODE:-all}"
+
+if [ -z "$STORE_PATH" ] || [ "$STORE_PATH" = "/" ]; then
+  echo "STORE_PATH must point to a dedicated data directory." >&2
+  exit 1
+fi
+
+mkdir -p "$STORE_PATH"
 
 index_docs() {
   echo "Indexing documentation..."
@@ -13,7 +22,9 @@ index_docs() {
     --scrape-mode fetch \
     --max-pages "$MAX_PAGES" \
     --max-depth "$MAX_DEPTH" \
+    --max-concurrency "$MAX_CONCURRENCY" \
     --exclude-pattern '/full-documentation\.txt/' \
+    --exclude-pattern '/\.md(?:\?.*)?$/' \
     --exclude-pattern '/developers/intelligent-contracts/?$/' \
     --exclude-pattern '/understand-genlayer-protocol/consensus/?$/' \
     --exclude-pattern '/validators/?$/'
@@ -22,7 +33,8 @@ index_docs() {
     --scope hostname \
     --scrape-mode fetch \
     --max-pages "$MAX_PAGES" \
-    --max-depth "$MAX_DEPTH"
+    --max-depth "$MAX_DEPTH" \
+    --max-concurrency "$MAX_CONCURRENCY"
 }
 
 index_is_usable() {
@@ -45,29 +57,55 @@ reset_index() {
   index_docs
 }
 
-if [ ! -f "$STORE_PATH/documents.db" ]; then
-  echo "No index found at $STORE_PATH/documents.db"
-  index_docs
-elif ! index_is_usable; then
-  echo "Existing index at $STORE_PATH/documents.db is not usable."
-  explain_index_failure
-  reset_index
-else
-  echo "Usable index found at $STORE_PATH/documents.db"
-fi
+verify_index() {
+  echo "Verifying index..."
+  if ! index_is_usable; then
+    echo "Index verification failed." >&2
+    explain_index_failure >&2
+    exit 1
+  fi
+  echo "Index verification complete."
+}
 
-echo "Verifying index..."
-if ! index_is_usable; then
-  echo "Index verification failed." >&2
-  explain_index_failure >&2
-  exit 1
-fi
-echo "Index verification complete."
+ensure_index() {
+  if [ ! -f "$STORE_PATH/documents.db" ]; then
+    echo "No index found at $STORE_PATH/documents.db"
+    index_docs
+  elif ! index_is_usable; then
+    echo "Existing index at $STORE_PATH/documents.db is not usable."
+    explain_index_failure
+    reset_index
+  else
+    echo "Usable index found at $STORE_PATH/documents.db"
+  fi
+  verify_index
+}
 
-echo "Starting docs-mcp-server..."
-exec docs-mcp-server mcp \
-  --port "$PORT" \
-  --host 0.0.0.0 \
-  --store-path "$STORE_PATH" \
-  --protocol http \
-  --read-only
+serve() {
+  verify_index
+  echo "Starting docs-mcp-server from docs revision ${DOCS_REVISION:-unknown}..."
+  exec docs-mcp-server mcp \
+    --port "$PORT" \
+    --host 0.0.0.0 \
+    --store-path "$STORE_PATH" \
+    --protocol http \
+    --read-only
+}
+
+case "$MODE" in
+  index)
+    reset_index
+    verify_index
+    ;;
+  serve)
+    serve
+    ;;
+  all)
+    ensure_index
+    serve
+    ;;
+  *)
+    echo "Unsupported MODE '$MODE'; expected index, serve, or all." >&2
+    exit 1
+    ;;
+esac

--- a/docs-mcp/smoke-test.mjs
+++ b/docs-mcp/smoke-test.mjs
@@ -2,12 +2,27 @@
 
 import { pathToFileURL } from "node:url";
 
-const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_TIMEOUT_MS = 20_000;
 const DEFAULT_EXPECTED_TOOL = "search_docs";
+const DEFAULT_PROTOCOL_VERSION = "2025-11-25";
+const DEFAULT_SEARCH = Object.freeze({
+  library: "genlayer-docs",
+  query: "equivalence principle",
+  limit: 3,
+  expectedText: "Equivalence Principle",
+  rejectMarkdownMirror: true,
+  rejectUndefinedMetadata: true,
+});
 
 function parsePositiveInteger(value, fallback) {
   const parsed = Number.parseInt(value ?? "", 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function inferTransport(endpoint) {
+  return new URL(endpoint).pathname.replace(/\/+$/, "").endsWith("/sse")
+    ? "sse"
+    : "streamable-http";
 }
 
 async function* parseSse(stream) {
@@ -65,23 +80,33 @@ async function waitForEvent(events, predicate, description) {
   }
 }
 
+function parseJsonRpcEvent(event, expectedId) {
+  if (event.event !== "message") {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(event.data);
+    return payload.id === expectedId ? payload : null;
+  } catch {
+    return null;
+  }
+}
+
 async function waitForJsonRpcResponse(events, id) {
   const event = await waitForEvent(
     events,
-    (candidate) => {
-      if (candidate.event !== "message") {
-        return false;
-      }
-      try {
-        return JSON.parse(candidate.data).id === id;
-      } catch {
-        return false;
-      }
-    },
+    (candidate) => parseJsonRpcEvent(candidate, id) !== null,
     `JSON-RPC response ${id}`,
   );
 
-  const payload = JSON.parse(event.data);
+  return assertJsonRpcSuccess(parseJsonRpcEvent(event, id), id);
+}
+
+function assertJsonRpcSuccess(payload, id) {
+  if (!payload) {
+    throw new Error(`JSON-RPC response ${id} was empty`);
+  }
   if (payload.error) {
     throw new Error(
       `JSON-RPC response ${id} failed: ${JSON.stringify(payload.error)}`,
@@ -95,7 +120,7 @@ async function responseError(response) {
   return `HTTP ${response.status}${body ? `: ${body.slice(0, 500)}` : ""}`;
 }
 
-async function postJson(url, payload, signal) {
+async function postSseJson(url, payload, signal) {
   const response = await fetch(url, {
     method: "POST",
     headers: {
@@ -111,34 +136,158 @@ async function postJson(url, payload, signal) {
   }
 }
 
-export async function runSmokeTest({
-  endpoint,
-  expectedTool = DEFAULT_EXPECTED_TOOL,
-  timeoutMs = DEFAULT_TIMEOUT_MS,
-} = {}) {
-  if (!endpoint) {
-    throw new Error("An MCP SSE endpoint is required");
+async function postStreamableJson(url, payload, signal) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`MCP HTTP endpoint returned ${await responseError(response)}`);
+  }
+  if (response.headers.has("mcp-session-id")) {
+    throw new Error(
+      "MCP HTTP endpoint created a session; the production endpoint must remain stateless",
+    );
+  }
+  if (response.status === 202 || payload.id === undefined) {
+    await response.body?.cancel().catch(() => {});
+    return null;
   }
 
-  const sseUrl = new URL(endpoint);
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  let events;
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  if (contentType.includes("application/json")) {
+    return assertJsonRpcSuccess(await response.json(), payload.id);
+  }
+  if (!contentType.includes("text/event-stream") || !response.body) {
+    throw new Error(
+      `MCP HTTP endpoint returned unsupported content type ${JSON.stringify(contentType)}`,
+    );
+  }
 
+  const events = parseSse(response.body);
   try {
-    const response = await fetch(sseUrl, {
-      headers: { Accept: "text/event-stream" },
-      signal: controller.signal,
-    });
+    return await waitForJsonRpcResponse(events, payload.id);
+  } finally {
+    await events.return().catch(() => {});
+  }
+}
 
-    if (!response.ok) {
-      throw new Error(`MCP SSE endpoint returned ${await responseError(response)}`);
-    }
-    if (!response.body) {
-      throw new Error("MCP SSE endpoint returned no response body");
-    }
+function initializeRequest(id, protocolVersion) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "initialize",
+    params: {
+      protocolVersion,
+      capabilities: {},
+      clientInfo: {
+        name: "genlayer-docs-mcp-smoke-test",
+        version: "2.0.0",
+      },
+    },
+  };
+}
 
-    events = parseSse(response.body);
+const initializedNotification = {
+  jsonrpc: "2.0",
+  method: "notifications/initialized",
+  params: {},
+};
+
+function toolsListRequest(id) {
+  return { jsonrpc: "2.0", id, method: "tools/list", params: {} };
+}
+
+function searchRequest(id, search) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "tools/call",
+    params: {
+      name: "search_docs",
+      arguments: {
+        library: search.library,
+        query: search.query,
+        limit: search.limit,
+      },
+    },
+  };
+}
+
+function validateTools(payload, expectedTool) {
+  const tools = payload.result?.tools;
+  if (!Array.isArray(tools)) {
+    throw new Error("MCP tools/list response did not contain a tools array");
+  }
+  if (expectedTool && !tools.some((tool) => tool.name === expectedTool)) {
+    throw new Error(
+      `MCP tool ${JSON.stringify(expectedTool)} was not advertised; received: ${tools
+        .map((tool) => tool.name)
+        .join(", ")}`,
+    );
+  }
+  return tools.map((tool) => tool.name);
+}
+
+function validateSearch(payload, search) {
+  if (payload.result?.isError) {
+    throw new Error("search_docs returned isError=true");
+  }
+
+  const text = (payload.result?.content ?? [])
+    .filter((item) => item.type === "text" && typeof item.text === "string")
+    .map((item) => item.text)
+    .join("\n");
+
+  if (!text) {
+    throw new Error("search_docs returned no text content");
+  }
+  if (
+    search.expectedText &&
+    !text.toLowerCase().includes(search.expectedText.toLowerCase())
+  ) {
+    throw new Error(
+      `search_docs did not contain expected text ${JSON.stringify(search.expectedText)}`,
+    );
+  }
+  if (
+    search.rejectMarkdownMirror &&
+    /Result \d+:\s+\S+\.md(?:[?#]\S*)?(?:\r?\n|$)/i.test(text)
+  ) {
+    throw new Error("search_docs returned a duplicate .md mirror result");
+  }
+  if (
+    search.rejectUndefinedMetadata &&
+    /(?:^|\r?\n)undefined(?:\r?\n|$)/i.test(text)
+  ) {
+    throw new Error("search_docs returned undefined result metadata");
+  }
+
+  return text;
+}
+
+async function runSseTest({ endpoint, expectedTool, protocolVersion, search, signal }) {
+  const sseUrl = new URL(endpoint);
+  const response = await fetch(sseUrl, {
+    headers: { Accept: "text/event-stream" },
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`MCP SSE endpoint returned ${await responseError(response)}`);
+  }
+  if (!response.body) {
+    throw new Error("MCP SSE endpoint returned no response body");
+  }
+
+  const events = parseSse(response.body);
+  try {
     const endpointEvent = await waitForEvent(
       events,
       (candidate) => candidate.event === "endpoint",
@@ -147,63 +296,99 @@ export async function runSmokeTest({
     const messagesUrl = new URL(endpointEvent.data, sseUrl);
 
     const initializeResponse = waitForJsonRpcResponse(events, 1);
-    await postJson(
+    await postSseJson(
       messagesUrl,
-      {
-        jsonrpc: "2.0",
-        id: 1,
-        method: "initialize",
-        params: {
-          protocolVersion: "2024-11-05",
-          capabilities: {},
-          clientInfo: {
-            name: "genlayer-docs-mcp-smoke-test",
-            version: "1.0.0",
-          },
-        },
-      },
-      controller.signal,
+      initializeRequest(1, protocolVersion),
+      signal,
     );
     const initialize = await initializeResponse;
 
-    await postJson(
-      messagesUrl,
-      {
-        jsonrpc: "2.0",
-        method: "notifications/initialized",
-        params: {},
-      },
-      controller.signal,
-    );
+    await postSseJson(messagesUrl, initializedNotification, signal);
 
     const toolsResponse = waitForJsonRpcResponse(events, 2);
-    await postJson(
-      messagesUrl,
-      {
-        jsonrpc: "2.0",
-        id: 2,
-        method: "tools/list",
-        params: {},
-      },
-      controller.signal,
-    );
-    const tools = (await toolsResponse).result?.tools;
+    await postSseJson(messagesUrl, toolsListRequest(2), signal);
+    const toolNames = validateTools(await toolsResponse, expectedTool);
 
-    if (!Array.isArray(tools)) {
-      throw new Error("MCP tools/list response did not contain a tools array");
-    }
-    if (expectedTool && !tools.some((tool) => tool.name === expectedTool)) {
-      throw new Error(
-        `MCP tool ${JSON.stringify(expectedTool)} was not advertised; received: ${tools
-          .map((tool) => tool.name)
-          .join(", ")}`,
-      );
+    let searchText = null;
+    if (search) {
+      const searchResponse = waitForJsonRpcResponse(events, 3);
+      await postSseJson(messagesUrl, searchRequest(3, search), signal);
+      searchText = validateSearch(await searchResponse, search);
     }
 
     return {
       serverInfo: initialize.result?.serverInfo ?? null,
-      toolNames: tools.map((tool) => tool.name),
+      toolNames,
+      searchValidated: searchText !== null,
     };
+  } finally {
+    await events.return().catch(() => {});
+  }
+}
+
+async function runStreamableHttpTest({
+  endpoint,
+  expectedTool,
+  protocolVersion,
+  search,
+  signal,
+}) {
+  const url = new URL(endpoint);
+  const initialize = await postStreamableJson(
+    url,
+    initializeRequest(1, protocolVersion),
+    signal,
+  );
+
+  await postStreamableJson(url, initializedNotification, signal);
+
+  const tools = await postStreamableJson(url, toolsListRequest(2), signal);
+  const toolNames = validateTools(tools, expectedTool);
+
+  let searchText = null;
+  if (search) {
+    searchText = validateSearch(
+      await postStreamableJson(url, searchRequest(3, search), signal),
+      search,
+    );
+  }
+
+  return {
+    serverInfo: initialize.result?.serverInfo ?? null,
+    toolNames,
+    searchValidated: searchText !== null,
+  };
+}
+
+export async function runSmokeTest({
+  endpoint,
+  transport = endpoint ? inferTransport(endpoint) : undefined,
+  expectedTool = DEFAULT_EXPECTED_TOOL,
+  protocolVersion = DEFAULT_PROTOCOL_VERSION,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  search = null,
+} = {}) {
+  if (!endpoint) {
+    throw new Error("An MCP endpoint is required");
+  }
+  if (!new Set(["sse", "streamable-http"]).has(transport)) {
+    throw new Error(`Unsupported MCP transport ${JSON.stringify(transport)}`);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const options = {
+      endpoint,
+      expectedTool,
+      protocolVersion,
+      search,
+      signal: controller.signal,
+    };
+    return transport === "sse"
+      ? await runSseTest(options)
+      : await runStreamableHttpTest(options);
   } catch (error) {
     if (controller.signal.aborted) {
       throw new Error(`MCP smoke test timed out after ${timeoutMs}ms`, {
@@ -214,9 +399,6 @@ export async function runSmokeTest({
   } finally {
     clearTimeout(timeout);
     controller.abort();
-    if (events) {
-      await events.return().catch(() => {});
-    }
   }
 }
 
@@ -224,20 +406,36 @@ async function main() {
   const endpoint =
     process.argv[2] ??
     process.env.DOCS_MCP_ENDPOINT ??
-    "https://docs-mcp.genlayer.com/sse";
+    "https://docs-mcp.genlayer.com/mcp";
   const timeoutMs = parsePositiveInteger(
     process.env.DOCS_MCP_TIMEOUT_MS,
     DEFAULT_TIMEOUT_MS,
   );
   const expectedTool =
     process.env.DOCS_MCP_EXPECTED_TOOL ?? DEFAULT_EXPECTED_TOOL;
+  const skipSearch = process.env.DOCS_MCP_SKIP_SEARCH === "true";
+  const search = skipSearch
+    ? null
+    : {
+        ...DEFAULT_SEARCH,
+        library: process.env.DOCS_MCP_SEARCH_LIBRARY ?? DEFAULT_SEARCH.library,
+        query: process.env.DOCS_MCP_SEARCH_QUERY ?? DEFAULT_SEARCH.query,
+        expectedText:
+          process.env.DOCS_MCP_SEARCH_EXPECTED_TEXT ?? DEFAULT_SEARCH.expectedText,
+        limit: parsePositiveInteger(
+          process.env.DOCS_MCP_SEARCH_LIMIT,
+          DEFAULT_SEARCH.limit,
+        ),
+      };
 
-  const result = await runSmokeTest({ endpoint, expectedTool, timeoutMs });
+  const result = await runSmokeTest({ endpoint, timeoutMs, search });
   const server = result.serverInfo
     ? `${result.serverInfo.name ?? "unknown"}@${result.serverInfo.version ?? "unknown"}`
     : "unknown";
   console.log(
-    `MCP smoke test passed: ${server}; tools: ${result.toolNames.join(", ")}`,
+    `MCP smoke test passed: ${server}; tools: ${result.toolNames.join(", ")}; search: ${
+      result.searchValidated ? "validated" : "skipped"
+    }`,
   );
 }
 

--- a/docs-mcp/smoke-test.test.mjs
+++ b/docs-mcp/smoke-test.test.mjs
@@ -5,6 +5,14 @@ import { afterEach, test } from "node:test";
 import { runSmokeTest } from "./smoke-test.mjs";
 
 const servers = [];
+const search = {
+  library: "genlayer-docs",
+  query: "equivalence principle",
+  limit: 3,
+  expectedText: "Equivalence Principle",
+  rejectMarkdownMirror: true,
+  rejectUndefinedMetadata: true,
+};
 
 afterEach(async () => {
   await Promise.all(
@@ -34,7 +42,27 @@ async function readJson(request) {
   return JSON.parse(Buffer.concat(chunks).toString("utf8"));
 }
 
-test("completes an MCP initialize and tools/list handshake", async () => {
+function resultFor(payload, searchText) {
+  switch (payload.method) {
+    case "initialize":
+      return {
+        protocolVersion: "2025-11-25",
+        capabilities: { tools: {} },
+        serverInfo: { name: "fixture", version: "1.0.0" },
+      };
+    case "tools/list":
+      return { tools: [{ name: "search_docs" }] };
+    case "tools/call":
+      return {
+        content: [{ type: "text", text: searchText }],
+        isError: false,
+      };
+    default:
+      throw new Error(`Unexpected fixture method ${payload.method}`);
+  }
+}
+
+test("validates the legacy SSE handshake and a real search", async () => {
   let sseResponse;
 
   const baseUrl = await listen(async (request, response) => {
@@ -54,24 +82,15 @@ test("completes an MCP initialize and tools/list handshake", async () => {
       const payload = await readJson(request);
       response.writeHead(202).end();
 
-      if (payload.method === "initialize") {
+      if (payload.id !== undefined) {
         sseResponse.write(
           `event: message\ndata: ${JSON.stringify({
             jsonrpc: "2.0",
             id: payload.id,
-            result: {
-              protocolVersion: "2024-11-05",
-              capabilities: { tools: {} },
-              serverInfo: { name: "fixture", version: "1.0.0" },
-            },
-          })}\n\n`,
-        );
-      } else if (payload.method === "tools/list") {
-        sseResponse.write(
-          `event: message\ndata: ${JSON.stringify({
-            jsonrpc: "2.0",
-            id: payload.id,
-            result: { tools: [{ name: "search_docs" }] },
+            result: resultFor(
+              payload,
+              "Result 1: https://docs.genlayer.com/equivalence-principle\nEquivalence Principle",
+            ),
           })}\n\n`,
         );
       }
@@ -84,13 +103,119 @@ test("completes an MCP initialize and tools/list handshake", async () => {
   const result = await runSmokeTest({
     endpoint: `${baseUrl}/sse`,
     timeoutMs: 2_000,
+    search,
   });
 
   assert.deepEqual(result.serverInfo, { name: "fixture", version: "1.0.0" });
   assert.deepEqual(result.toolNames, ["search_docs"]);
+  assert.equal(result.searchValidated, true);
 });
 
-test("reports an upstream SSE failure", async () => {
+test("validates stateless Streamable HTTP without sending a session id", async () => {
+  const methods = [];
+  const sessionHeaders = [];
+
+  const baseUrl = await listen(async (request, response) => {
+    const url = new URL(request.url, "http://localhost");
+    if (request.method !== "POST" || url.pathname !== "/mcp") {
+      response.writeHead(404).end();
+      return;
+    }
+
+    const payload = await readJson(request);
+    methods.push(payload.method);
+    sessionHeaders.push(request.headers["mcp-session-id"]);
+
+    if (payload.id === undefined) {
+      response.writeHead(202).end();
+      return;
+    }
+
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(
+      `event: message\ndata: ${JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: resultFor(
+          payload,
+          "Result 1: https://docs.genlayer.com/equivalence-principle\nEquivalence Principle",
+        ),
+      })}\n\n`,
+    );
+  });
+
+  const result = await runSmokeTest({
+    endpoint: `${baseUrl}/mcp`,
+    timeoutMs: 2_000,
+    search,
+  });
+
+  assert.deepEqual(methods, [
+    "initialize",
+    "notifications/initialized",
+    "tools/list",
+    "tools/call",
+  ]);
+  assert.deepEqual(sessionHeaders, [undefined, undefined, undefined, undefined]);
+  assert.deepEqual(result.toolNames, ["search_docs"]);
+  assert.equal(result.searchValidated, true);
+});
+
+test("rejects duplicate Markdown mirror search results", async () => {
+  const baseUrl = await listen(async (request, response) => {
+    const payload = await readJson(request);
+    if (payload.id === undefined) {
+      response.writeHead(202).end();
+      return;
+    }
+
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: resultFor(
+          payload,
+          "Result 1: https://docs.genlayer.com/equivalence-principle\nEquivalence Principle\nResult 2: https://docs.genlayer.com/equivalence-principle.md\nEquivalence Principle",
+        ),
+      }),
+    );
+  });
+
+  await assert.rejects(
+    runSmokeTest({ endpoint: `${baseUrl}/mcp`, timeoutMs: 2_000, search }),
+    /duplicate \.md mirror result/,
+  );
+});
+
+test("rejects undefined search result metadata", async () => {
+  const baseUrl = await listen(async (request, response) => {
+    const payload = await readJson(request);
+    if (payload.id === undefined) {
+      response.writeHead(202).end();
+      return;
+    }
+
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: resultFor(
+          payload,
+          "Result 1: https://docs.genlayer.com/equivalence-principle\nundefined\nEquivalence Principle",
+        ),
+      }),
+    );
+  });
+
+  await assert.rejects(
+    runSmokeTest({ endpoint: `${baseUrl}/mcp`, timeoutMs: 2_000, search }),
+    /undefined result metadata/,
+  );
+});
+
+test("reports an upstream Streamable HTTP failure", async () => {
   const baseUrl = await listen((_request, response) => {
     response.writeHead(502, { "Content-Type": "text/plain" });
     response.end("bad gateway");
@@ -98,9 +223,9 @@ test("reports an upstream SSE failure", async () => {
 
   await assert.rejects(
     runSmokeTest({
-      endpoint: `${baseUrl}/sse`,
+      endpoint: `${baseUrl}/mcp`,
       timeoutMs: 2_000,
     }),
-    /MCP SSE endpoint returned HTTP 502: bad gateway/,
+    /MCP HTTP endpoint returned HTTP 502: bad gateway/,
   );
 });

--- a/pages/developers/intelligent-contracts/tooling-setup.mdx
+++ b/pages/developers/intelligent-contracts/tooling-setup.mdx
@@ -340,11 +340,21 @@ claude mcp add genlayer npx -- -y genlayer-mcp
 The **GenLayer Docs MCP Server** gives your AI agent searchable access to the full GenLayer documentation and SDK reference — so it can look up APIs, patterns, and examples while writing code:
 
 ```bash
-# Add to Claude Code
+# Codex uses the stateless Streamable HTTP endpoint
+codex mcp add genlayer-docs --url https://docs-mcp.genlayer.com/mcp
+
+# Claude Code can use the legacy SSE compatibility endpoint
 claude mcp add genlayer-docs --transport sse https://docs-mcp.genlayer.com/sse
 ```
 
-This is a hosted service — no local setup required. It provides a `search_docs` tool that searches across both the [GenLayer documentation](https://docs.genlayer.com) and the [GenLayer SDK reference](https://sdk.genlayer.com). Compatible with any MCP client (Claude Code, Cursor, Windsurf, etc.).
+This is a hosted service — no local setup required. It provides a `search_docs` tool that searches across both the [GenLayer documentation](https://docs.genlayer.com) and the [GenLayer SDK reference](https://sdk.genlayer.com). Use `https://docs-mcp.genlayer.com/mcp` for clients that support Streamable HTTP; `/sse` remains available for legacy SSE clients.
+
+<Callout emoji="🩺">
+  A plain HTTP status check does not prove that MCP search works. If the hosted
+  server is unavailable, use [docs.genlayer.com](https://docs.genlayer.com), the
+  [SDK reference](https://sdk.genlayer.com), or the GenLayer Skills plugin as a
+  temporary fallback and retry later.
+</Callout>
 
 The boilerplate also includes a `CLAUDE.md` file pre-configured with commands, architecture context, and testing patterns — so agents understand the project structure immediately.
 


### PR DESCRIPTION
## Problem and outcome

The AWS migration preserved a working but fragile deployment contract: clients were still directed to legacy SSE, the image pinned `@arabold/docs-mcp-server` 2.4.0, docs and `.md` mirrors produced duplicate search hits, malformed result metadata leaked as `undefined`, and the health check only proved a handshake. Docs-only releases also needed a distinct, traceable image digest before GitOps could promote them safely.

This makes stateless Streamable HTTP at `/mcp` the primary Codex/client path, upgrades the server to 3.0.1, preserves `/sse` compatibility, separates index and serve lifecycle modes, excludes Markdown mirrors, and adds real Docs + SDK search-quality canaries and incident issue management.

Publishing the image is still not a deployment. The dependent AWS workload change is being reviewed separately and will consume the immutable digest produced after this PR lands.

## Implementation and validation

- embeds the source SHA and server version in OCI labels, ensuring docs-only releases produce a promotable digest;
- adds stateless Streamable HTTP and legacy SSE protocol coverage, real search calls, duplicate-mirror rejection, and undefined-metadata rejection;
- bundles the canary into the image for post-rollout verification;
- documents the `/mcp` Codex setup and the release/rollback contract.

Validated locally with:

- Node 22 MCP tests: 5/5 passing;
- `npm run build`: production Next.js build passing;
- `actionlint`, `shellcheck`, shell syntax, Node syntax, and diff checks;
- exact `@arabold/docs-mcp-server@3.0.1` CLI flag inspection;
- local v3.0.1 read-only `/mcp` and `/sse` handshakes with only read tools exposed;
- public legacy SSE and SDK search canaries passing;
- the new public Docs search canary failing for the known current `.md` duplicate, as intended until rollout.

The local Docker daemon did not become responsive within a bounded retry, so the GitHub image build remains the authoritative container-build gate. No dependency files changed.

## Rollout and rollback

Land this image producer first. After GHCR publishes the labeled digest, update the dependent GitOps draft to that immutable digest and let its Argo/image/search gates control deployment. Rollback is an immutable manifest revert in the workload repository; no database data is authoritative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for both Streamable HTTP and legacy SSE connections to the Docs MCP service.
  - Improved documentation search validation to return accurate results and exclude unwanted Markdown mirrors.
  - Added clearer setup guidance for Codex and Claude Code, including endpoint selection and fallback options.

- **Bug Fixes**
  - Enhanced health monitoring, failure detection, incident tracking, and recovery handling.

- **Documentation**
  - Expanded deployment, rollback, troubleshooting, and service operations guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->