### PR TITLE
docs(docs-mcp): describe immutable promotion

### DIFF
--- a/.github/workflows/docs-mcp.yml
+++ b/.github/workflows/docs-mcp.yml
@@ -62,5 +62,5 @@ jobs:
             echo
             echo "- Source: \`${{ github.sha }}\`"
             echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
-            echo "- GitOps: \`genlayerlabs/devexp-argocd-apps\` polls the labeled \`latest\` image and promotes this digest"
+            echo "- GitOps: \`genlayerlabs/devexp-argocd-apps\` promotes \`sha-${{ github.sha }}\` by immutable digest and waits for production verification"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs-mcp/OPERATIONS.md
+++ b/docs-mcp/OPERATIONS.md
@@ -18,9 +18,13 @@ Merges to `main` that change `docs-mcp/**` or `pages/**` publish `latest` and
 `org.opencontainers.image.revision` label, so a docs-only change produces a new
 image digest even when the server files are unchanged.
 
-`devexp-argocd-apps` polls that labeled release, resolves its immutable digest,
-opens and auto-merges a one-line-or-two-line workload bump PR, and lets ArgoCD
-roll the StatefulSet. The deployment is complete only after:
+`devexp-argocd-apps` reads the current `genlayer-docs` `main` revision, waits
+for its matching `sha-<commit>` image, validates the image's embedded source
+provenance through its immutable digest, opens and auto-merges the workload
+bump PR, and lets ArgoCD roll the StatefulSet. The promoter remains active
+until production verification finishes, so a later release cannot enter the
+lane while the current one is still being verified. The deployment is complete
+only after:
 
 1. ArgoCD reports the exact GitOps revision synced and healthy;
 2. the workload is running the expected immutable digest;
@@ -30,8 +34,11 @@ roll the StatefulSet. The deployment is complete only after:
 4. the legacy `/sse` compatibility handshake still succeeds.
 
 The GitOps verification workflow restores the previous `docs-mcp` manifests
-when a rollout or public canary fails. Scheduled canary failures create or
-update an incident issue in this repository and close it after recovery.
+when a rollout or its public canaries fail. Those deployment incidents are
+owned and tracked in `devexp-argocd-apps`. Separately,
+`docs-mcp-health.yml` runs the three public canaries every 15 minutes; ongoing
+service-health incidents are owned and tracked in this repository. Each
+workflow closes only the incident type it owns after recovery.
 
 ## Index lifecycle
 
@@ -120,7 +127,8 @@ The production workload must continue to:
 5. make readiness and ingress health depend on the MCP process;
 6. wait for ArgoCD convergence and run both public protocol canaries;
 7. restore the previous manifests automatically when verification fails; and
-8. open an incident issue when the scheduled production canary fails.
+8. track rollout-verification incidents in `devexp-argocd-apps` and scheduled
+   production-health incidents in `genlayer-docs`.
 
 Do not restore the removed `POST /web/jobs/scrape` workflow call. That route is
 not exposed by the read-only `docs-mcp-server mcp` runtime.


### PR DESCRIPTION
## Problem and outcome

The source repository still said the GitOps promoter polled the mutable `latest` tag, but production now resolves the current source revision through its `sha-<commit>` tag and immutable digest. This updates the operator contract to match the merged release lane.

## Implementation and validation

- Describe source-SHA selection, immutable provenance validation, promotion serialization, and the production completion criteria.
- Correct the image-build summary so it points operators to the exact `sha-<commit>` artifact and production verification.
- Clarify that verification failures are tracked in the GitOps repository.

Validation:
- `actionlint .github/workflows/docs-mcp.yml`
- `git diff --check`
- reviewed as a two-file wording-only change against current `main`

Merging this PR intentionally publishes a new Docs MCP image for this source revision. The merged GitOps lane will use that release as an end-to-end automation check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the release workflow for immutable, SHA-tagged image promotion and production verification.
  - Documented deployment safeguards, including provenance validation and prevention of overlapping verification releases.
  - Updated failure-handling guidance to reference GitOps-managed incident issues for any production verification failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->