### PR TITLE
docs: fix SDK API reference snippets

### DIFF
--- a/pages/api-references/genlayer-js.md
+++ b/pages/api-references/genlayer-js.md
@@ -69,11 +69,10 @@ const client = createClient({
 });
 
 const result = await client.readContract({
-  // account: account, Account is optional when reading from contracts
+  // account is optional when reading from contracts
   address: contractAddress,
   functionName: 'get_complete_storage',
-  args: []
-  stateStatus: "accepted",
+  args: [],
 })
 ```
 
@@ -81,24 +80,25 @@ const result = await client.readContract({
 ```typescript
 import { localnet } from 'genlayer-js/chains';
 import { createClient, createAccount } from "genlayer-js";
+import { TransactionStatus } from "genlayer-js/types";
 
 const client = createClient({
-  network: localnet,
+  chain: localnet,
 });
 
 const account = createAccount();
 const transactionHash = await client.writeContract({
-  account: account, // using this account for this transaction
+  account, // using this account for this transaction
   address: contractAddress,
-  functionName: 'account',
+  functionName: 'update_storage',
   args: ['new_storage'],
-  value: 0, // value is optional, if you want to send some native token to the contract
+  value: BigInt(0), // native token value to send with the transaction
 });
 
 const receipt = await client.waitForTransactionReceipt({
-  hash: txHash,
+  hash: transactionHash,
   status: TransactionStatus.FINALIZED, // or ACCEPTED
-  fullTransaction: false // False by default - returns simplified receipt for better readability
+  fullTransaction: false, // False by default - returns simplified receipt for better readability
 })
 
 ```

--- a/pages/api-references/genlayer-py.md
+++ b/pages/api-references/genlayer-py.md
@@ -79,8 +79,9 @@ result = client.read_contract(
 
 ### Writing a transaction
 ```python
-from genlayer_py.chains import localnet
 from genlayer_py import create_client, create_account
+from genlayer_py.chains import localnet
+from genlayer_py.types import TransactionStatus
 
 client = create_client(
     chain=localnet,
@@ -90,16 +91,15 @@ account = create_account()
 
 transaction_hash = client.write_contract(
     account=account,
-    transaction=transaction,
     address=contract_address,
-    function_name='account',
+    function_name='update_storage',
     args=['new_storage'],
-    value=0, // value is optional, if you want to send some native token to the contract
+    value=0,  # native token value to send with the transaction
 )
 receipt = client.wait_for_transaction_receipt(
-    hash=transaction_hash,
-    status=TransactionStatus.FINALIZED, // or ACCEPTED
-    full_transaction=False  // False by default - returns simplified receipt for better readability
+    transaction_hash=transaction_hash,
+    status=TransactionStatus.FINALIZED,  # or ACCEPTED
+    full_transaction=False,  # False by default - returns simplified receipt for better readability
 )
 ```
 


### PR DESCRIPTION
## Summary
- Fix invalid TypeScript and Python snippets in the GenLayerJS and GenLayerPY API reference pages.
- Align the write-contract examples with the documented SDK parameter names and transaction hash variable names.
- Remove a stale read-contract option from the quick GenLayerJS example.

## Sanitized evidence basis
A weekly gap-loop source audit found copy-paste and syntax issues in the public SDK API reference snippets. These pages are used by builders as quick-start references, so broken snippets can create unnecessary onboarding friction even without a fresh support thread.

## Test plan
- `pnpm build` — passed locally.
- Python code fences in `pages/api-references/genlayer-py.md` parse with `ast.parse`.

Created by weekly docs-and-skills gap loop; draft for human review.
